### PR TITLE
feat: expand hidden lines

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -45,12 +45,14 @@ mark_on_submit = true
 | `layout` | `"auto"` | `"auto"`, `"flow"` or `"split"`. `flow` is the one-column diff; `split` is side by side. `auto` is responsive: side by side when the pane is wide enough, flow when it is not. `\|` or `-` switches views for the session, and switching beats `auto`. `"unified"` is accepted as a spelling of `"flow"` |
 | `highlight` | `"line"` | `"line"` washes the whole changed row; `"gutter"` keeps the colour in the sign and the line number and leaves the code to the syntax highlighting |
 | `split_min_width` | `100` | Below this many columns, `auto` reads flow. Each side needs a line number, a sign, a gutter and about forty columns of code, with a divider between them; under that, side by side wraps so hard it shows less than the flow view. Minimum 60, which is the floor below |
+| `expand_lines` | `10` | Lines `K` and `J` pull in around a hunk each press. Git shows three either side and the buffers hold the rest, so this is how much of the rest arrives at a time. Between 1 and 500 |
 
 ```toml
 [diff]
 layout = "auto"
 highlight = "line"
 split_min_width = 100
+expand_lines = 10
 ```
 
 The wash colours are mixed from the theme rather than written per theme: the

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -314,7 +314,9 @@ with `zc`.
 Git shows three lines either side of a change; `lgtm` holds the whole file, so
 `K` and `J` pull more of it in above and below the hunk the cursor is on, ten
 lines a press (`[diff] expand_lines`). The rule between two hunks says lines are
-hidden there, so it goes when they meet. `zc` folds a file's context back.
+hidden there, so it goes when they meet. `zc` folds the context of the hunk
+under the cursor back again, the way it closes a fold in vim; the other hunks
+keep theirs, and `zf` folds the lot.
 
 A file that is not text - an image, a binary, an archive - never renders its
 bytes. It gets one row saying what it is, how big it is, and for an image how
@@ -410,7 +412,9 @@ A second `,` keeps going back rather than turning round, the way vim's does.
 | `\|` or `-` | side by side, or back to the flow view |
 | `H` `L` | side by side: focus the old or the new column |
 | `zi` | show the files `[review] ignore` hides |
-| `zo` `zc` | open a file too large to render inline, or fold it |
+| `zo` | open a file too large to render inline |
+| `zc` | fold this hunk's context back, or a file opened with `zo` |
+| `zf` | fold every hunk's context in this file |
 | `K` `J` | show more of the file above or below this hunk |
 | `<C-r>` | re-diff now |
 | `<Space>e` | open this line in `$EDITOR` |

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -311,6 +311,11 @@ An unchanged file opens whole, outside the review — still readable, still
 commentable. A file too large to render inline opens with `zo` and folds again
 with `zc`.
 
+Git shows three lines either side of a change; `lgtm` holds the whole file, so
+`K` and `J` pull more of it in above and below the hunk the cursor is on, ten
+lines a press (`[diff] expand_lines`). The rule between two hunks says lines are
+hidden there, so it goes when they meet. `zc` folds a file's context back.
+
 A file that is not text - an image, a binary, an archive - never renders its
 bytes. It gets one row saying what it is, how big it is, and for an image how
 large: `PNG image | 1200x630 | 8.5 KB`.
@@ -406,6 +411,7 @@ A second `,` keeps going back rather than turning round, the way vim's does.
 | `H` `L` | side by side: focus the old or the new column |
 | `zi` | show the files `[review] ignore` hides |
 | `zo` `zc` | open a file too large to render inline, or fold it |
+| `K` `J` | show more of the file above or below this hunk |
 | `<C-r>` | re-diff now |
 | `<Space>e` | open this line in `$EDITOR` |
 | `?` | every key, from your bindings |

--- a/src/config.zig
+++ b/src/config.zig
@@ -83,6 +83,11 @@ pub const Diff = struct {
     /// side by side wraps so hard it shows less than the flow view it
     /// replaced.
     split_min_width: u16 = 100,
+    /// Lines `K` and `J` pull in each press. Ten rather than three: three is
+    /// what git already showed and asking twice for one screenful is a key
+    /// worn out on a question the reader only asked once. A whole screen is
+    /// too much for the pane this is designed for, which is half of one.
+    expand_lines: u16 = 10,
 };
 
 pub const Ui = struct {
@@ -341,6 +346,16 @@ pub const Loader = struct {
                         return;
                     }
                     self.cfg.diff.split_min_width = @intCast(n);
+                } else if (std.mem.eql(u8, key, "expand_lines")) {
+                    const n = self.wantInt(src, line, key, value) orelse return;
+                    // One line is a slow way to read a file and 500 is the
+                    // file. Both ends catch a typo rather than hold an opinion
+                    // about what is comfortable in between.
+                    if (n < 1 or n > 500) {
+                        self.note(src, line, "diff.expand_lines must be between 1 and 500", .{});
+                        return;
+                    }
+                    self.cfg.diff.expand_lines = @intCast(n);
                 } else self.unknownKey(src, line, section, key);
             },
             .ui => {
@@ -752,6 +767,7 @@ pub const starter =
     \\# layout = "auto"           # "auto", "flow" (one column), or "split"
     \\# highlight = "line"        # "line" washes the row, "gutter" the sign
     \\# split_min_width = 100     # under this many columns, "auto" reads flow
+    \\# expand_lines = 10         # lines K and J pull in around a hunk
     \\
     \\# [ui]
     \\# icons = "unicode"         # "unicode", "ascii", or "nerd" (patched font)

--- a/src/core/diff.zig
+++ b/src/core/diff.zig
@@ -79,7 +79,18 @@ pub const ParseError = error{MalformedHunkHeader} || Allocator.Error;
 /// output the file was parsed from.
 pub fn materialise(gpa: Allocator, f: *FileDiff, raw: []const u8) ParseError!void {
     if (!f.summarised) return;
-    if (f.raw_hi > raw.len or f.raw_lo >= f.raw_hi) return;
+    if (try reparse(gpa, f, raw)) f.summarised = false;
+}
+
+/// Puts a file back to what git said about it, from the output git already
+/// gave. Returns false when the bytes are not there to do it with - a
+/// synthesised entry for an untracked file has no section of its own.
+///
+/// What `materialise` is built on, and what folding pulled-out context back
+/// uses: growing a hunk's context edits `hunks` and `lines` in place, and this
+/// is how the reader gets git's own answer back without git being asked again.
+pub fn reparse(gpa: Allocator, f: *FileDiff, raw: []const u8) ParseError!bool {
+    if (f.raw_hi > raw.len or f.raw_lo >= f.raw_hi) return false;
 
     const one = try parseLimited(gpa, raw[f.raw_lo..f.raw_hi], std.math.maxInt(u32));
     defer gpa.free(one.files);
@@ -88,13 +99,13 @@ pub fn materialise(gpa: Allocator, f: *FileDiff, raw: []const u8) ParseError!voi
             gpa.free(x.hunks);
             x.lines.deinit(gpa);
         }
-        return;
+        return false;
     }
 
     const full = one.files[0];
     f.hunks = full.hunks;
     f.lines = full.lines;
-    f.summarised = false;
+    return true;
 }
 
 /// Parses unified diff text. Unknown or unsupported sections are skipped rather

--- a/src/core/expand.zig
+++ b/src/core/expand.zig
@@ -321,3 +321,35 @@ test "growing a summarised file does nothing" {
     f.summarised = true;
     try testing.expectEqual(@as(u32, 0), try grow(a, f, work, 0, .up, 3));
 }
+
+test "a re-parse puts a grown file back to what git said" {
+    var arena: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    const raw =
+        \\diff --git a/f.txt b/f.txt
+        \\--- a/f.txt
+        \\+++ b/f.txt
+        \\@@ -5 +5 @@
+        \\-five
+        \\+FIVE
+        \\
+    ;
+    var d = try parseOne(a, raw);
+    const work: Buffer = try .initOwned(a, try a.dupe(u8, eight));
+    const f = &d.files[0];
+    const was = f.lines.len();
+
+    _ = try grow(a, f, work, 0, .up, 3);
+    try testing.expect(f.lines.len() > was);
+
+    // What folding context back is built on: git's own answer, out of the
+    // output already in hand, with no second subprocess.
+    try testing.expect(try diff.reparse(a, f, raw));
+    try testing.expectEqual(was, f.lines.len());
+    try testing.expectEqual(@as(u32, 5), f.hunks[0].new_start);
+    try testing.expectEqual(@as(u32, 1), f.hunks[0].new_count);
+    try testing.expectEqual(@as(u32, 0), f.hunks[0].lo);
+    try testing.expectEqual(@as(u32, 2), f.hunks[0].hi);
+}

--- a/src/core/expand.zig
+++ b/src/core/expand.zig
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: Apache-2.0
+//
+// Growing a hunk's context out of the buffers.
+//
+// Git emits three lines either side of a change and forgets the rest. The
+// buffers hold the whole file, which is the reason `core/source.zig` exists,
+// so the lines around a hunk are already in memory: showing them is an
+// insertion into `DiffLines`, not another subprocess and not a re-diff.
+//
+// Growing rather than re-rendering is what keeps this off the keystroke
+// budget. One press adds a few lines to one hunk, so the work is a single pass
+// over that file's lines; nothing re-lexes and no id is reassigned. The change
+// ids survive because `hashHunk` hashes added and removed lines only, and
+// context is exactly what it ignores.
+//
+// The clamps are what stop two hunks from being drawn over the same lines. A
+// hunk never grows past the file, and never past the hunk next door - which
+// may itself have grown towards this one, so the two ranges meet and stop.
+//
+// A hunk with no lines on one side sits *between* two lines of that file
+// rather than on any of them: `@@ -4,3 +3,0 @@` deletes after new line 3. That
+// is what `before` and `after` are for, and why neither is `start - 1` and
+// `start + count`.
+
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const diff = @import("diff.zig");
+const hunk = @import("hunk.zig");
+const Hunk = hunk.Hunk;
+const Buffer = @import("../text/buffer.zig").Buffer;
+
+pub const Dir = enum { up, down };
+
+/// Last new-file line before the hunk. Zero when it starts at the file's head.
+fn newBefore(h: Hunk) u32 {
+    return if (h.new_count == 0) h.new_start else h.new_start -| 1;
+}
+
+/// First new-file line after the hunk.
+fn newAfter(h: Hunk) u32 {
+    return if (h.new_count == 0) h.new_start + 1 else h.new_start + h.new_count;
+}
+
+fn oldBefore(h: Hunk) u32 {
+    return if (h.old_count == 0) h.old_start else h.old_start -| 1;
+}
+
+fn oldAfter(h: Hunk) u32 {
+    return if (h.old_count == 0) h.old_start + 1 else h.old_start + h.old_count;
+}
+
+/// How many lines hunk `hi` can still grow in `dir`. Zero means the reader has
+/// reached the top of the file, the bottom of it, or the hunk next door.
+pub fn room(f: *const diff.FileDiff, work: Buffer, hi: u32, dir: Dir) u32 {
+    if (hi >= f.hunks.len) return 0;
+    const h = f.hunks[hi];
+    return switch (dir) {
+        .up => {
+            const floor: u32 = if (hi == 0) 1 else newAfter(f.hunks[hi - 1]);
+            return (newBefore(h) + 1) -| floor;
+        },
+        .down => {
+            const ceil: u32 = if (hi + 1 < f.hunks.len)
+                newBefore(f.hunks[hi + 1])
+            else
+                work.lineCount();
+            return (ceil + 1) -| newAfter(h);
+        },
+    };
+}
+
+/// Adds up to `want` context lines to one side of hunk `hi`, taking their text
+/// from the working-tree buffer. Returns how many were added.
+///
+/// The buffer is the source of truth, so the text is the buffer's own slice -
+/// the same one `source.attach` hands every other line, with the same lifetime.
+///
+/// `gpa` is the diff arena: the old line arrays are abandoned rather than
+/// freed, which is what an arena is for and what every other builder here
+/// does.
+pub fn grow(
+    gpa: Allocator,
+    f: *diff.FileDiff,
+    work: Buffer,
+    hi: u32,
+    dir: Dir,
+    want: u32,
+) Allocator.Error!u32 {
+    if (want == 0 or f.summarised or hi >= f.hunks.len) return 0;
+    const add = @min(want, room(f, work, hi, dir));
+    if (add == 0) return 0;
+
+    const h = &f.hunks[hi];
+    // Where the block lands: the row in `lines`, and its first line in each
+    // file. Old-file numbering runs a fixed distance from new-file numbering
+    // outside the change, and the two ends of a hunk keep different distances.
+    const at: u32 = switch (dir) {
+        .up => h.lo,
+        .down => h.hi,
+    };
+    const first_new: u32 = switch (dir) {
+        .up => newBefore(h.*) + 1 - add,
+        .down => newAfter(h.*),
+    };
+    const first_old: u32 = switch (dir) {
+        .up => oldBefore(h.*) + 1 - add,
+        .down => oldAfter(h.*),
+    };
+
+    const old_len: u32 = @intCast(f.lines.len());
+    var out: hunk.DiffLines = .{
+        .kind = try gpa.alloc(hunk.LineKind, old_len + add),
+        .old_no = try gpa.alloc(u32, old_len + add),
+        .new_no = try gpa.alloc(u32, old_len + add),
+        .text = try gpa.alloc([]const u8, old_len + add),
+    };
+
+    copyLines(&out, 0, f.lines, 0, at);
+    for (0..add) |k| {
+        const i = at + k;
+        out.kind[i] = .context;
+        out.new_no[i] = first_new + @as(u32, @intCast(k));
+        out.old_no[i] = first_old + @as(u32, @intCast(k));
+        out.text[i] = work.line(out.new_no[i] - 1) orelse "";
+    }
+    copyLines(&out, at + add, f.lines, at, old_len);
+    f.lines = out;
+
+    // The block is inside the hunk either way, so `lo` does not move and `hi`
+    // grows by what was added. Every later hunk sits that far down the list.
+    h.new_start = switch (dir) {
+        .up => first_new,
+        .down => if (h.new_count == 0) first_new else h.new_start,
+    };
+    h.old_start = switch (dir) {
+        .up => first_old,
+        .down => if (h.old_count == 0) first_old else h.old_start,
+    };
+    h.new_count += add;
+    h.old_count += add;
+    h.hi += add;
+    for (f.hunks[hi + 1 ..]) |*later| {
+        later.lo += add;
+        later.hi += add;
+    }
+    return add;
+}
+
+fn copyLines(out: *hunk.DiffLines, at: u32, from: hunk.DiffLines, lo: u32, hi: u32) void {
+    const n = hi - lo;
+    if (n == 0) return;
+    @memcpy(out.kind[at .. at + n], from.kind[lo..hi]);
+    @memcpy(out.old_no[at .. at + n], from.old_no[lo..hi]);
+    @memcpy(out.new_no[at .. at + n], from.new_no[lo..hi]);
+    @memcpy(out.text[at .. at + n], from.text[lo..hi]);
+}
+
+const testing = std.testing;
+
+/// The eight-line file two of the fixtures below diff, so the buffer and the
+/// patch cannot drift apart.
+const eight = "one\ntwo\nthree\nfour\nFIVE\nsix\nseven\neight\n";
+
+fn parseOne(gpa: Allocator, text: []const u8) !diff.Diff {
+    return diff.parse(gpa, text);
+}
+
+test "growing up and down takes its text and numbering from the buffer" {
+    var arena: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var d = try parseOne(a,
+        \\diff --git a/f.txt b/f.txt
+        \\--- a/f.txt
+        \\+++ b/f.txt
+        \\@@ -5 +5 @@
+        \\-five
+        \\+FIVE
+        \\
+    );
+    const work: Buffer = try .initOwned(a, try a.dupe(u8, eight));
+    const f = &d.files[0];
+
+    try testing.expectEqual(@as(u32, 2), try grow(a, f, work, 0, .up, 2));
+    try testing.expectEqual(@as(u32, 3), f.hunks[0].new_start);
+    try testing.expectEqual(@as(u32, 3), f.hunks[0].new_count);
+    try testing.expectEqualStrings("three", f.lines.text[0]);
+    try testing.expectEqualStrings("four", f.lines.text[1]);
+    try testing.expectEqual(@as(u32, 3), f.lines.new_no[0]);
+    // Context lines carry both numberings, and here the two files agree.
+    try testing.expectEqual(@as(u32, 3), f.lines.old_no[0]);
+    try testing.expectEqual(hunk.LineKind.context, f.lines.kind[0]);
+
+    try testing.expectEqual(@as(u32, 3), try grow(a, f, work, 0, .down, 3));
+    try testing.expectEqual(@as(u32, 6), f.hunks[0].new_count);
+    // Two lines of change plus five of context, the deleted line among them.
+    try testing.expectEqual(@as(usize, 7), f.lines.len());
+    try testing.expectEqualStrings("six", f.lines.text[4]);
+    try testing.expectEqualStrings("eight", f.lines.text[6]);
+    // The hunk still covers every line of the file's list, in order.
+    try testing.expectEqual(@as(u32, 0), f.hunks[0].lo);
+    try testing.expectEqual(@as(u32, 7), f.hunks[0].hi);
+}
+
+test "a hunk never grows past the file it is in" {
+    var arena: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var d = try parseOne(a,
+        \\diff --git a/f.txt b/f.txt
+        \\--- a/f.txt
+        \\+++ b/f.txt
+        \\@@ -5 +5 @@
+        \\-five
+        \\+FIVE
+        \\
+    );
+    const work: Buffer = try .initOwned(a, try a.dupe(u8, eight));
+    const f = &d.files[0];
+
+    // Four above and three below is the whole file; asking for a hundred
+    // gets exactly that and then nothing.
+    try testing.expectEqual(@as(u32, 4), try grow(a, f, work, 0, .up, 100));
+    try testing.expectEqual(@as(u32, 3), try grow(a, f, work, 0, .down, 100));
+    try testing.expectEqual(@as(usize, 9), f.lines.len());
+    try testing.expectEqual(@as(u32, 0), room(f, work, 0, .up));
+    try testing.expectEqual(@as(u32, 0), room(f, work, 0, .down));
+    try testing.expectEqual(@as(u32, 0), try grow(a, f, work, 0, .up, 1));
+}
+
+test "two hunks growing towards each other meet and stop" {
+    var arena: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // Twenty lines, changed at 3 and at 17.
+    var text: std.ArrayList(u8) = .empty;
+    for (1..21) |i| try text.print(a, "line{d}\n", .{i});
+    const body = try text.toOwnedSlice(a);
+    const work: Buffer = try .initOwned(a, body);
+
+    var d = try parseOne(a,
+        \\diff --git a/f.txt b/f.txt
+        \\--- a/f.txt
+        \\+++ b/f.txt
+        \\@@ -3 +3 @@
+        \\-old3
+        \\+line3
+        \\@@ -17 +17 @@
+        \\-old17
+        \\+line17
+        \\
+    );
+    const f = &d.files[0];
+
+    // The first hunk takes everything down to the second one and no further.
+    try testing.expectEqual(@as(u32, 13), try grow(a, f, work, 0, .down, 100));
+    try testing.expectEqual(@as(u32, 16), f.hunks[0].new_start + f.hunks[0].new_count - 1);
+    // Which leaves the second nothing above it to take.
+    try testing.expectEqual(@as(u32, 0), room(f, work, 1, .up));
+    try testing.expectEqual(@as(u32, 0), try grow(a, f, work, 1, .up, 5));
+
+    // The second hunk's range into the line list moved by what the first grew.
+    try testing.expectEqual(f.hunks[0].hi, f.hunks[1].lo);
+    try testing.expectEqual(@as(u32, 3), try grow(a, f, work, 1, .down, 3));
+    try testing.expectEqual(@as(u32, 20), f.hunks[1].new_start + f.hunks[1].new_count - 1);
+}
+
+test "a pure deletion grows on the lines either side of where it was" {
+    var arena: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    // `gone` was line 4 of the old file; the new file has seven lines.
+    var d = try parseOne(a,
+        \\diff --git a/f.txt b/f.txt
+        \\--- a/f.txt
+        \\+++ b/f.txt
+        \\@@ -4 +3,0 @@
+        \\-gone
+        \\
+    );
+    const work: Buffer = try .initOwned(a, try a.dupe(u8, "one\ntwo\nthree\nfour\nfive\nsix\nseven\n"));
+    const f = &d.files[0];
+    try testing.expectEqual(@as(u32, 0), f.hunks[0].new_count);
+
+    // Up takes line 3, the last one before the deletion.
+    try testing.expectEqual(@as(u32, 1), try grow(a, f, work, 0, .up, 1));
+    try testing.expectEqualStrings("three", f.lines.text[0]);
+    try testing.expectEqual(@as(u32, 3), f.lines.new_no[0]);
+    try testing.expectEqual(@as(u32, 3), f.lines.old_no[0]);
+    try testing.expectEqual(@as(u32, 3), f.hunks[0].new_start);
+    try testing.expectEqual(@as(u32, 1), f.hunks[0].new_count);
+
+    // Down takes line 4, the first one after it - which was line 5 of the old
+    // file, the deleted line having been 4.
+    try testing.expectEqual(@as(u32, 1), try grow(a, f, work, 0, .down, 1));
+    try testing.expectEqualStrings("four", f.lines.text[2]);
+    try testing.expectEqual(@as(u32, 4), f.lines.new_no[2]);
+    try testing.expectEqual(@as(u32, 5), f.lines.old_no[2]);
+}
+
+test "growing a summarised file does nothing" {
+    var arena: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer arena.deinit();
+    const a = arena.allocator();
+
+    var d = try parseOne(a,
+        \\diff --git a/f.txt b/f.txt
+        \\--- a/f.txt
+        \\+++ b/f.txt
+        \\@@ -5 +5 @@
+        \\-five
+        \\+FIVE
+        \\
+    );
+    const work: Buffer = try .initOwned(a, try a.dupe(u8, eight));
+    const f = &d.files[0];
+    f.summarised = true;
+    try testing.expectEqual(@as(u32, 0), try grow(a, f, work, 0, .up, 3));
+}

--- a/src/core/git.zig
+++ b/src/core/git.zig
@@ -28,8 +28,7 @@ pub const Error = proc.RunError || diff.ParseError || error{ GitFailed, NotARepo
 fn insideRepo(gpa: Allocator, io: std.Io, repo: ?[]const u8) bool {
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(gpa);
-    argv.append(gpa, "git") catch return false;
-    if (repo) |r| argv.appendSlice(gpa, &.{ "-C", r }) catch return false;
+    proc.gitArgv(gpa, &argv, repo) catch return false;
     argv.appendSlice(gpa, &.{ "rev-parse", "--git-dir" }) catch return false;
 
     const out = proc.run(gpa, io, argv.items, 1 << 12) catch return false;
@@ -125,8 +124,7 @@ fn diffBase(
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(gpa);
 
-    try argv.append(gpa, "git");
-    if (repo) |r| try argv.appendSlice(gpa, &.{ "-C", r });
+    try proc.gitArgv(gpa, &argv, repo);
     // `HEAD` normally, `--cached` in a repository whose first commit has not
     // happened yet - see the retry below.
     try argv.appendSlice(gpa, &.{ "diff", base });
@@ -276,8 +274,7 @@ fn untracked(
 ) Error!Untracked {
     var argv: std.ArrayList([]const u8) = .empty;
     defer argv.deinit(gpa);
-    try argv.append(gpa, "git");
-    if (repo) |r| try argv.appendSlice(gpa, &.{ "-C", r });
+    try proc.gitArgv(gpa, &argv, repo);
     try argv.appendSlice(gpa, &.{ "ls-files", "--others", "--exclude-standard" });
     // The same exclusions the tracked side got. A new generated file is still
     // a generated file, and hiding it from one half of the review only would
@@ -386,7 +383,7 @@ fn synthesiseAdd(gpa: Allocator, path: []const u8, bytes: []const u8) Allocator.
 /// Paths that differ from HEAD, for the watcher to narrow re-diffs to.
 /// One subprocess instead of N stat calls.
 pub fn changedPaths(gpa: Allocator, io: std.Io) Error![][]const u8 {
-    const out = try proc.run(gpa, io, &.{ "git", "diff", "HEAD", "--name-only" }, max_diff_bytes);
+    const out = try proc.run(gpa, io, &.{ "git", "--no-optional-locks", "diff", "HEAD", "--name-only" }, max_diff_bytes);
     defer out.deinit(gpa);
     if (out.exit_code != 0) return error.GitFailed;
 
@@ -425,8 +422,8 @@ pub fn snapshotPaths(gpa: Allocator, io: std.Io) Error![][]const u8 {
         for (list.items) |p| gpa.free(p);
         list.deinit(gpa);
     }
-    try collectPaths(gpa, io, &list, &.{ "git", "diff", "HEAD", "--name-only" });
-    try collectPaths(gpa, io, &list, &.{ "git", "ls-files", "--others", "--exclude-standard" });
+    try collectPaths(gpa, io, &list, &.{ "git", "--no-optional-locks", "diff", "HEAD", "--name-only" });
+    try collectPaths(gpa, io, &list, &.{ "git", "--no-optional-locks", "ls-files", "--others", "--exclude-standard" });
     return list.toOwnedSlice(gpa);
 }
 
@@ -461,7 +458,7 @@ fn collectPaths(
 /// a directory the agent creates is seen: the parent fires when a subdirectory
 /// appears under it, and the caller adds the new one.
 pub fn trackedDirs(gpa: Allocator, io: std.Io) Error![][]const u8 {
-    const out = try proc.run(gpa, io, &.{ "git", "ls-files" }, max_diff_bytes);
+    const out = try proc.run(gpa, io, &.{ "git", "--no-optional-locks", "ls-files" }, max_diff_bytes);
     defer out.deinit(gpa);
     if (out.exit_code != 0) return error.GitFailed;
 
@@ -508,7 +505,7 @@ pub const max_files = 50_000;
 /// result, about 9.5 ms at 200,000 paths, which is what `max_files` is for.
 pub fn projectFiles(gpa: Allocator, io: std.Io) Error![][]const u8 {
     const out = try proc.run(gpa, io, &.{
-        "git", "ls-files", "--cached", "--others", "--exclude-standard",
+        "git", "--no-optional-locks", "ls-files", "--cached", "--others", "--exclude-standard",
     }, max_diff_bytes);
     defer out.deinit(gpa);
     if (out.exit_code != 0) return error.GitFailed;
@@ -538,8 +535,8 @@ pub fn projectFiles(gpa: Allocator, io: std.Io) Error![][]const u8 {
 /// count came out short.
 pub fn hiddenCount(gpa: Allocator, io: std.Io, ignore: []const []const u8, base: []const u8) u32 {
     if (ignore.len == 0) return 0;
-    return countMatching(gpa, io, &.{ "git", "diff", base, "--name-only" }, ignore) +
-        countMatching(gpa, io, &.{ "git", "ls-files", "--others", "--exclude-standard" }, ignore);
+    return countMatching(gpa, io, &.{ "git", "--no-optional-locks", "diff", base, "--name-only" }, ignore) +
+        countMatching(gpa, io, &.{ "git", "--no-optional-locks", "ls-files", "--others", "--exclude-standard" }, ignore);
 }
 
 fn countMatching(gpa: Allocator, io: std.Io, base: []const []const u8, pats: []const []const u8) u32 {

--- a/src/core/source.zig
+++ b/src/core/source.zig
@@ -105,8 +105,7 @@ pub fn loadAt(
     if (wanted.items.len > 0) {
         var argv: std.ArrayList([]const u8) = .empty;
         defer argv.deinit(gpa);
-        try argv.append(gpa, "git");
-        if (repo) |r| try argv.appendSlice(gpa, &.{ "-C", r });
+        try proc.gitArgv(gpa, &argv, repo);
         try argv.appendSlice(gpa, &.{ "cat-file", "--batch" });
 
         const out = try proc.runWithInput(gpa, io, argv.items, req.items, max_blob_bytes);
@@ -137,8 +136,7 @@ pub fn loadAt(
         if (wwant.items.len > 0) {
             var argv: std.ArrayList([]const u8) = .empty;
             defer argv.deinit(gpa);
-            try argv.append(gpa, "git");
-            if (repo) |r| try argv.appendSlice(gpa, &.{ "-C", r });
+            try proc.gitArgv(gpa, &argv, repo);
             try argv.appendSlice(gpa, &.{ "cat-file", "--batch" });
 
             const out = try proc.runWithInput(gpa, io, argv.items, wreq.items, max_blob_bytes);

--- a/src/io/proc.zig
+++ b/src/io/proc.zig
@@ -19,6 +19,34 @@ pub const Output = struct {
     }
 };
 
+/// Opens a `git` argv: the program, the flag that keeps it out of the reader's
+/// way, and `-C <repo>` when there is one.
+///
+/// `--no-optional-locks` is the load-bearing part, and it lives here rather
+/// than at each call site because forgetting it once is enough to break
+/// somebody's rebase. `git status` and `git diff` refresh the index as a side
+/// effect and write it back under `.git/index.lock`; this tool runs both on a
+/// timer, against a repository whose owner is also using it. Two seconds into a
+/// `git pull --rebase` the reader gets
+///
+///     error: Unable to create '.git/index.lock': File exists.
+///     hint: Could not execute the todo command
+///
+/// from their *own* git, and the rebase stops mid-way. The flag drops the
+/// optional write and changes no answer, which is what it exists for.
+///
+/// Only *optional* locks: a command whose job is to write an index still
+/// writes one, so the snapshot store's plumbing is unaffected - it has an
+/// index of its own through `GIT_INDEX_FILE` and never touches the repo's.
+pub fn gitArgv(
+    gpa: Allocator,
+    argv: *std.ArrayList([]const u8),
+    repo: ?[]const u8,
+) Allocator.Error!void {
+    try argv.appendSlice(gpa, &.{ "git", "--no-optional-locks" });
+    if (repo) |r| try argv.appendSlice(gpa, &.{ "-C", r });
+}
+
 /// Runs argv to completion and captures stdout. Used for `git diff` and the
 /// bridge backends, which are the only subprocesses lgtm spawns.
 pub fn run(gpa: Allocator, io: Io, argv: []const []const u8, max_output: usize) RunError!Output {
@@ -67,6 +95,25 @@ pub fn runEnv(
             else => 1,
         },
     };
+}
+
+test "every git invocation carries --no-optional-locks" {
+    const gpa = std.testing.allocator;
+    var argv: std.ArrayList([]const u8) = .empty;
+    defer argv.deinit(gpa);
+
+    try gitArgv(gpa, &argv, null);
+    try std.testing.expectEqualStrings("git", argv.items[0]);
+    // Second, and before any subcommand: it is a top-level option, and a
+    // reader mid-rebase is what it is there for.
+    try std.testing.expectEqualStrings("--no-optional-locks", argv.items[1]);
+    try std.testing.expectEqual(@as(usize, 2), argv.items.len);
+
+    argv.clearRetainingCapacity();
+    try gitArgv(gpa, &argv, "/tmp/repo");
+    try std.testing.expectEqualStrings("--no-optional-locks", argv.items[1]);
+    try std.testing.expectEqualStrings("-C", argv.items[2]);
+    try std.testing.expectEqualStrings("/tmp/repo", argv.items[3]);
 }
 
 test "run captures stdout" {

--- a/src/io/watch.zig
+++ b/src/io/watch.zig
@@ -196,8 +196,7 @@ pub const Poller = struct {
     fn scan(self: *Poller) !std.ArrayList(Entry) {
         var argv: std.ArrayList([]const u8) = .empty;
         defer argv.deinit(self.gpa);
-        try argv.append(self.gpa, "git");
-        if (self.opts.repo) |r| try argv.appendSlice(self.gpa, &.{ "-C", r });
+        try proc.gitArgv(self.gpa, &argv, self.opts.repo);
         try argv.appendSlice(self.gpa, &.{ "status", "--porcelain", "--untracked-files=all" });
 
         const out = try proc.run(self.gpa, self.io, argv.items, 16 << 20);

--- a/src/lib.zig
+++ b/src/lib.zig
@@ -26,6 +26,7 @@ pub const review = @import("core/review.zig");
 pub const event = @import("core/event.zig");
 pub const binary = @import("core/binary.zig");
 pub const diff = @import("core/diff.zig");
+pub const expand = @import("core/expand.zig");
 pub const git = @import("core/git.zig");
 pub const hunk = @import("core/hunk.zig");
 pub const source = @import("core/source.zig");
@@ -51,6 +52,7 @@ test {
     _ = event;
     _ = binary;
     _ = diff;
+    _ = expand;
     _ = git;
     _ = hunk;
     _ = source;

--- a/src/snapshot/snapshot.zig
+++ b/src/snapshot/snapshot.zig
@@ -270,7 +270,7 @@ pub fn readPaths(
         try req.append(gpa, '\n');
     }
 
-    const out = try proc.runWithInput(gpa, io, &.{ "git", "cat-file", "--batch" }, req.items, 64 << 20);
+    const out = try proc.runWithInput(gpa, io, &.{ "git", "--no-optional-locks", "cat-file", "--batch" }, req.items, 64 << 20);
     defer out.deinit(gpa);
     // Non-zero means the ref is gone - pruned, or someone deleted it. Not an
     // error worth surfacing: the mark simply cannot be restored, and an empty

--- a/src/snapshot/timeline.zig
+++ b/src/snapshot/timeline.zig
@@ -92,10 +92,10 @@ pub fn read(
     // ids are what makes a self-revert detectable. `--no-abbrev` because two
     // abbreviated ids that match may still be two different blobs.
     const out = try proc.run(gpa, io, &.{
-        "git",                         "log",
-        "--format=%x00%H %ct%n%B%x01", "--numstat",
-        "--raw",                       "--no-abbrev",
-        head_ref,
+        "git",         "--no-optional-locks",
+        "log",         "--format=%x00%H %ct%n%B%x01",
+        "--numstat",   "--raw",
+        "--no-abbrev", head_ref,
     }, 8 << 20);
     errdefer out.deinit(gpa);
     if (out.exit_code != 0) {

--- a/src/ui/app.zig
+++ b/src/ui/app.zig
@@ -18,6 +18,7 @@ const std = @import("std");
 const Allocator = std.mem.Allocator;
 
 const diff = @import("../core/diff.zig");
+const expand = @import("../core/expand.zig");
 const event = @import("../core/event.zig");
 const fs_mod = @import("../io/fs.zig");
 const git = @import("../core/git.zig");
@@ -324,6 +325,9 @@ pub const App = struct {
     /// in a pane this narrow are each narrower than the code in them, and the
     /// mode that is worse in the home environment must not appear there.
     split_min_width: u16 = 100,
+    /// `[diff] expand_lines`. How much of the file `K` and `J` pull in around
+    /// a hunk each press.
+    expand_lines: u16 = 10,
     /// Which column of a split row the cursor is in, moved by `H` and `L`.
     /// The new file by default: it is the code that is there now, and it is
     /// what a reference, a comment and a yank are almost always about.
@@ -553,6 +557,43 @@ pub const App = struct {
         // is re-anchored through `core/anchor.zig`; the row index is only the
         // fallback for a line that is genuinely gone.
         try self.rebuildRows(.line);
+    }
+
+    /// `K` and `J`: more of the file around the hunk the cursor is on.
+    ///
+    /// The cursor holds its *line*, not its row. Growing upwards inserts rows
+    /// above it, so keeping the row index would slide the cursor onto whatever
+    /// text moved under it - and the scroll offset is left alone on purpose,
+    /// which is what makes the new lines appear where the reader was looking
+    /// rather than off the top of the pane.
+    fn growContext(self: *App, body: u16, dir: expand.Dir) !void {
+        const f = self.current() orelse return;
+        if (f.summarised or f.status == .binary) return;
+        const hi = self.rows.hunkAt(self.vp.cursor) orelse {
+            self.notice.set("no hunk here to open out", .{});
+            return;
+        };
+        const line = self.cursorLine();
+        const want = self.expand_lines;
+        const got = self.review.growContext(f.path(), hi, dir, want) catch 0;
+        if (got == 0) {
+            self.notice.set("nothing left to show {s} this hunk", .{
+                if (dir == .up) "above" else "below",
+            });
+            return;
+        }
+
+        // `current()` is re-read: the file lives in the diff arena and the
+        // grow replaced its line arrays.
+        try self.rebuildRows(.row);
+        if (self.current()) |g| {
+            if (line != 0) {
+                if (self.rowForFileLine(g, line)) |r| self.vp.cursor = r;
+            }
+        }
+        self.clampScroll(body);
+        self.placeCursor();
+        self.notice.set("{d} more line{s}", .{ got, if (got == 1) "" else "s" });
     }
 
     fn rebuildRows(self: *App, keep: Keep) !void {
@@ -990,8 +1031,24 @@ pub const App = struct {
                     self.notice.set("this file cannot be opened inline", .{});
                 }
             },
+            // Git shows three lines either side of a change and forgets the
+            // rest; the buffers held the whole file all along. These are the
+            // keys that ask for it.
+            .expand_up, .expand_down => try self.growContext(
+                body,
+                if (cmd == .expand_up) .up else .down,
+            ),
             .collapse_file => {
                 const f = self.current() orelse return;
+                // A file the reader has pulled context into folds that back
+                // first. `zc` is the fold key, and pulled-out context is a
+                // fold that has been opened by any other name.
+                if (!f.summarised and self.review.collapseContext(f.path())) {
+                    try self.rediff();
+                    self.clampScroll(body);
+                    self.notice.set("context folded", .{});
+                    return;
+                }
                 if (f.summarised) {
                     self.notice.set("this file is already folded", .{});
                     return;
@@ -2020,6 +2077,30 @@ pub const App = struct {
         fx.app.layout = .split;
         fx.app.relayout(20);
         try testing.expect(fx.app.split);
+    }
+
+    test "a hunk header does not send the cursor back across the pane" {
+        var fx = try Fixture.init(testing.allocator);
+        defer fx.deinit();
+        try splitReplacement(fx);
+
+        const halves = rows_mod.Split.of(fx.app.vp.cols);
+        const gutter = rows_mod.gutter(&fx.files[0], .split);
+
+        // Row 0 is the hunk header: chrome, drawn across the whole pane, with
+        // no pair to take a side from. It takes the reader's side instead, or
+        // every `j` over a header would cross the pane and come back.
+        fx.app.side = .new;
+        fx.app.vp.cursor = 0;
+        const right = fx.app.cursorCell(body_rows).?;
+        try testing.expectEqual(
+            @as(f32, @floatFromInt(halves.column(.new).at + gutter)),
+            right.col,
+        );
+
+        fx.app.side = .old;
+        const left = fx.app.cursorCell(body_rows).?;
+        try testing.expectEqual(@as(f32, @floatFromInt(gutter)), left.col);
     }
 
     test "H and L put the cursor in the other column of a split row" {
@@ -4572,8 +4653,19 @@ pub const App = struct {
         // Whichever column `lineAt` chose, and never outside it: a cursor
         // standing in the other half would say the reader is pointing at a
         // line they are not.
+        //
+        // Chrome has no pair to take a side from, so it takes the reader's.
+        // A hunk header is drawn across the whole pane and is shorter than the
+        // code either side of it, so the column that fits it is the one the
+        // cursor is already in - and crossing the pane to sit on a header and
+        // crossing back on the next `j` reads as the view losing the reader's
+        // place. A row that genuinely has nothing on one side is a different
+        // case and still moves the cursor, which is `sideOn`'s answer.
+        const halves = rows_mod.Split.of(self.vp.cols);
         const half: ?rows_mod.Split.Column = if (self.rows.pairAt(row)) |p|
-            rows_mod.Split.of(self.vp.cols).column(self.sideOn(p))
+            halves.column(self.sideOn(p))
+        else if (self.split)
+            halves.column(self.side)
         else
             null;
         const base: u16 = if (half) |h| h.at else 0;
@@ -4585,9 +4677,12 @@ pub const App = struct {
         // Parking it at the first text column keeps it visible and keeps it
         // moving - returning null here blinks it out for a frame and then
         // teleports it, which is what a held `j` looked like.
-        const li = self.lineAt(row) orelse
-            return .{ .row = @floatFromInt(y), .col = @floatFromInt(gutter) };
-        if (li >= f.lines.len()) return .{ .row = @floatFromInt(y), .col = @floatFromInt(gutter) };
+        const parked: anim.Cursor.Cell = .{
+            .row = @floatFromInt(y),
+            .col = @floatFromInt(base + gutter),
+        };
+        const li = self.lineAt(row) orelse return parked;
+        if (li >= f.lines.len()) return parked;
 
         const avail = if (self.wrap) column -| gutter else 0;
         const cell = wrap_mod.locate(f.lines.text[li], avail, self.vp.metrics, self.vp.col);

--- a/src/ui/app.zig
+++ b/src/ui/app.zig
@@ -596,6 +596,29 @@ pub const App = struct {
         self.notice.set("{d} more line{s}", .{ got, if (got == 1) "" else "s" });
     }
 
+    /// Where the cursor goes after a hunk's context is folded away. Its line
+    /// is the first answer and is often gone with the fold, so the hunk it was
+    /// reading is the second - never the row index it happened to hold, which
+    /// after the fold belongs to a line further down the file.
+    fn foldedTo(self: *App, hi: u32, body: u16) !void {
+        const line = self.cursorLine();
+        try self.rebuildRows(.row);
+        const f = self.current() orelse return;
+        if (line != 0) {
+            if (self.rowForFileLine(f, line)) |r| {
+                self.vp.cursor = r;
+                self.clampScroll(body);
+                self.placeCursor();
+                return;
+            }
+        }
+        if (hi < self.rows.hunk_rows.len) {
+            self.vp.cursor = @min(self.rows.hunk_rows[hi] + 1, self.rows.len() -| 1);
+        }
+        self.clampScroll(body);
+        self.placeCursor();
+    }
+
     fn rebuildRows(self: *App, keep: Keep) !void {
         const f = self.current() orelse {
             self.rows = rows_mod.Rows.empty;
@@ -1038,16 +1061,33 @@ pub const App = struct {
                 body,
                 if (cmd == .expand_up) .up else .down,
             ),
+            // `zf`: every window in the file, not just the one at the cursor.
+            .collapse_context => {
+                const f = self.current() orelse return;
+                const hi = self.rows.hunkAt(self.vp.cursor) orelse 0;
+                if (self.review.foldAllContext(f.path()) catch false) {
+                    try self.foldedTo(hi, body);
+                    self.notice.set("context folded in this file", .{});
+                } else {
+                    self.notice.set("no context to fold here", .{});
+                }
+            },
             .collapse_file => {
                 const f = self.current() orelse return;
-                // A file the reader has pulled context into folds that back
-                // first. `zc` is the fold key, and pulled-out context is a
-                // fold that has been opened by any other name.
-                if (!f.summarised and self.review.collapseContext(f.path())) {
-                    try self.rediff();
-                    self.clampScroll(body);
-                    self.notice.set("context folded", .{});
-                    return;
+                // Context the reader pulled in folds before the file does:
+                // `zc` closes the innermost thing open at the cursor, which is
+                // what it means in vim and what it should mean here. One hunk,
+                // because `K` and `J` open one - closing the file's other
+                // windows from a hunk the reader is standing nowhere near
+                // would be a fold key with a blast radius.
+                if (!f.summarised) {
+                    if (self.rows.hunkAt(self.vp.cursor)) |hi| {
+                        if (self.review.foldContext(f.path(), hi) catch false) {
+                            try self.foldedTo(hi, body);
+                            self.notice.set("context folded", .{});
+                            return;
+                        }
+                    }
                 }
                 if (f.summarised) {
                     self.notice.set("this file is already folded", .{});

--- a/src/ui/keymap.zig
+++ b/src/ui/keymap.zig
@@ -125,6 +125,15 @@ pub const Command = enum {
     /// everything but name, and vim already decided what those keys mean.
     expand_file,
     collapse_file,
+    /// Pull more of the file in around the hunk the cursor is on. Git shows
+    /// three lines either side; the buffers hold the rest, so these are the
+    /// keys that ask for it, `[diff] expand_lines` at a time.
+    ///
+    /// `K` and `J` because the direction is the whole of what they mean and
+    /// vim already spells up and down that way. Both are free in the body -
+    /// they move the selection in a list, and a list is a different mode.
+    expand_up,
+    expand_down,
     copy_text,
     copy_text_lines,
     copy_ref,
@@ -516,6 +525,8 @@ pub const default_bindings: []const Binding = &.{
     .{ .chords = &.{ c('z'), c('i') }, .command = .toggle_ignored, .desc = "show the files [review] ignore hides", .group = .view },
     .{ .chords = &.{ c('z'), c('o') }, .command = .expand_file, .desc = "open a file too large to render inline, or fold it again", .group = .view },
     .{ .chords = &.{ c('z'), c('c') }, .command = .collapse_file, .desc = "open a file too large to render inline, or fold it again", .hint = null, .group = .view },
+    .{ .chords = &.{c('K')}, .command = .expand_up, .desc = "show more of the file above and below this hunk", .group = .view },
+    .{ .chords = &.{c('J')}, .command = .expand_down, .desc = "show more of the file above and below this hunk", .hint = null, .group = .view },
     .{ .chords = &.{c(':')}, .command = .command_line, .hint = "quit", .hint_keys = ":q", .desc = "command line (:q)", .group = .view },
     // `<C-r>` and not `<C-l>`: vim-tmux-navigator binds C-h/C-j/C-k/C-l at the
     // tmux *root* table and forwards them only to processes matching its vim

--- a/src/ui/keymap.zig
+++ b/src/ui/keymap.zig
@@ -120,9 +120,11 @@ pub const Command = enum {
     /// `w` for weakened, and it is the one letter in that family still free.
     next_risk,
     prev_risk,
-    /// A file over `large_file_lines` renders as a summary row; these open it
-    /// and fold it again. `zo` and `zc` because a deferred file is a fold in
-    /// everything but name, and vim already decided what those keys mean.
+    /// A file over `large_file_lines` renders as a summary row; `zo` opens it.
+    /// `zc` closes the innermost thing open at the cursor, which is vim's
+    /// meaning of it: the context `K` and `J` pulled into this hunk first, and
+    /// the file itself once there is none. A deferred file is a fold in
+    /// everything but name, and so is a window into one.
     expand_file,
     collapse_file,
     /// Pull more of the file in around the hunk the cursor is on. Git shows
@@ -134,6 +136,16 @@ pub const Command = enum {
     /// they move the selection in a list, and a list is a different mode.
     expand_up,
     expand_down,
+    /// `zf`: fold every window in this file at once. `zc` closes the one under
+    /// the cursor, and a reader who opened five hunks wants one press rather
+    /// than five and a hunt for where they were.
+    ///
+    /// Not vim's `zM`, which is the spelling for this, and not vim's `zf`,
+    /// which creates a fold over a motion. There is no fold to create here -
+    /// nothing in this tool folds a range the reader points at - so the key is
+    /// free, and `f` for fold reads better than a shifted `M` on something
+    /// pressed at the end of every file.
+    collapse_context,
     copy_text,
     copy_text_lines,
     copy_ref,
@@ -523,10 +535,11 @@ pub const default_bindings: []const Binding = &.{
     .{ .chords = &.{ leader, c('n'), c('m') }, .command = .next_fresh, .group = .turns },
     .{ .chords = &.{ leader, c('p'), c('m') }, .command = .prev_fresh, .group = .turns },
     .{ .chords = &.{ c('z'), c('i') }, .command = .toggle_ignored, .desc = "show the files [review] ignore hides", .group = .view },
-    .{ .chords = &.{ c('z'), c('o') }, .command = .expand_file, .desc = "open a file too large to render inline, or fold it again", .group = .view },
-    .{ .chords = &.{ c('z'), c('c') }, .command = .collapse_file, .desc = "open a file too large to render inline, or fold it again", .hint = null, .group = .view },
+    .{ .chords = &.{ c('z'), c('o') }, .command = .expand_file, .desc = "open a file too large to render inline", .group = .view },
+    .{ .chords = &.{ c('z'), c('c') }, .command = .collapse_file, .desc = "fold this hunk's context back, or a file opened with zo", .hint = null, .group = .view },
     .{ .chords = &.{c('K')}, .command = .expand_up, .desc = "show more of the file above and below this hunk", .group = .view },
     .{ .chords = &.{c('J')}, .command = .expand_down, .desc = "show more of the file above and below this hunk", .hint = null, .group = .view },
+    .{ .chords = &.{ c('z'), c('f') }, .command = .collapse_context, .desc = "fold every hunk's context in this file", .group = .view },
     .{ .chords = &.{c(':')}, .command = .command_line, .hint = "quit", .hint_keys = ":q", .desc = "command line (:q)", .group = .view },
     // `<C-r>` and not `<C-l>`: vim-tmux-navigator binds C-h/C-j/C-k/C-l at the
     // tmux *root* table and forwards them only to processes matching its vim

--- a/src/ui/loop.zig
+++ b/src/ui/loop.zig
@@ -87,6 +87,7 @@ pub fn run(gpa: Allocator, io: std.Io, environ: *std.process.Environ.Map, opts: 
     app.wrap = opts.cfg.ui.wrap;
     app.layout = opts.cfg.diff.layout;
     app.split_min_width = opts.cfg.diff.split_min_width;
+    app.expand_lines = opts.cfg.diff.expand_lines;
     app.highlight = switch (opts.cfg.diff.highlight) {
         .gutter => .gutter,
         .line => .line,

--- a/src/ui/review.zig
+++ b/src/ui/review.zig
@@ -19,6 +19,7 @@ const checkpoint = @import("../core/checkpoint.zig");
 const testrisk = @import("../core/testrisk.zig");
 const snapshot = @import("../snapshot/snapshot.zig");
 const diff = @import("../core/diff.zig");
+const expand_mod = @import("../core/expand.zig");
 const git = @import("../core/git.zig");
 const hunk = @import("../core/hunk.zig");
 const source = @import("../core/source.zig");
@@ -47,6 +48,14 @@ pub const Carry = struct {
     /// Zero when the cursor was on chrome or on a deleted line, neither of
     /// which has a line in the new file to carry anywhere.
     line: u32 = 0,
+};
+
+/// One hunk's pulled-out context: how far it has been grown either way.
+pub const Context = struct {
+    path: []u8,
+    hunk: u32,
+    above: u32 = 0,
+    below: u32 = 0,
 };
 
 pub const Review = struct {
@@ -132,6 +141,19 @@ pub const Review = struct {
     /// written, which is the only time you want to.
     expanded: std.ArrayList([]u8) = .empty,
 
+    /// Context the reader has pulled out of the buffers, per hunk. gpa-owned
+    /// and re-applied after every re-diff, for the reason `expanded` is: a
+    /// window that closed itself each time the agent typed would be a window
+    /// you could not read while it was being written.
+    ///
+    /// Keyed by the hunk's position in its file rather than by its change id,
+    /// which is the more stable of the two here: `inherit` is handed the
+    /// previous hunks only for the file the cursor is in, so every other
+    /// file's ids are reissued on each re-diff and a key made of one would
+    /// match nothing. A hunk appearing above this one moves the expansion to
+    /// its neighbour, which the next keypress corrects.
+    context: std.ArrayList(Context) = .empty,
+
     /// The mark, and what changed after it. The mark is gpa-owned for the same
     /// reason `prev_work` is; `fresh` is one bool per row of each file and
     /// belongs to the generation, because rows do.
@@ -157,6 +179,8 @@ pub const Review = struct {
         self.mark_at.deinit();
         for (self.expanded.items) |p| self.gpa.free(p);
         self.expanded.deinit(self.gpa);
+        for (self.context.items) |c| self.gpa.free(c.path);
+        self.context.deinit(self.gpa);
         self.gpa.free(self.prev_work);
         self.ids.deinit(self.gpa);
         self.cache.deinit(self.gpa);
@@ -347,6 +371,10 @@ pub const Review = struct {
             const prev: []const hunk.Hunk = if (i == index) carried else &.{};
             try self.ids.inherit(arena, prev, f.hunks);
         }
+
+        // Last, and after the ids: the rows `fresh` and `risk` are counted
+        // over have to be the rows the reader will see, context and all.
+        try self.applyContext();
 
         try self.refresh();
         try self.scanRisk();
@@ -610,6 +638,92 @@ pub const Review = struct {
 
         try self.remember(path);
         return true;
+    }
+
+    /// Pulls `want` more lines of context out of the buffers, on one side of
+    /// the hunk the reader is on, and remembers that it did.
+    ///
+    /// Returns how many lines arrived: fewer than asked at the edge of a file
+    /// or against the hunk next door, and zero when there is nothing left to
+    /// show. The caller says so rather than leaving a key that looks broken.
+    pub fn growContext(self: *Review, path: []const u8, hi: u32, dir: expand_mod.Dir, want: u32) !u32 {
+        const p = self.parsed orelse return 0;
+        const f = find(p.diff.files, path) orelse return 0;
+        const work = self.buffersFor(path).work orelse return 0;
+        const got = try expand_mod.grow(self.arena.allocator(), f, work, hi, dir, want);
+        if (got == 0) return 0;
+
+        const c = try self.contextFor(path, hi);
+        switch (dir) {
+            .up => c.above += got,
+            .down => c.below += got,
+        }
+        return got;
+    }
+
+    /// Forgets what a file had been grown by. The caller rebuilds; this only
+    /// stops the next re-diff from putting the context back, which is the same
+    /// shape `collapse` has.
+    pub fn collapseContext(self: *Review, path: []const u8) bool {
+        var found = false;
+        var i: usize = 0;
+        while (i < self.context.items.len) {
+            if (std.mem.eql(u8, self.context.items[i].path, path)) {
+                self.gpa.free(self.context.items[i].path);
+                _ = self.context.swapRemove(i);
+                found = true;
+                continue;
+            }
+            i += 1;
+        }
+        return found;
+    }
+
+    /// Puts back what the reader had pulled out, on the generation that has
+    /// just replaced the one they pulled it out of.
+    ///
+    /// Each entry is asked for what it actually got last time, not for what
+    /// was typed: a change that closed the gap between two hunks leaves less
+    /// room, and recording the smaller answer is what stops the request from
+    /// growing back the moment the gap reopens.
+    ///
+    /// Two hunks reaching for the same lines are settled by whichever is
+    /// applied first, which is the order they were expanded in. Nothing can
+    /// overlap however the tie falls - `grow` clamps against the hunk next
+    /// door either way - so the cost of the arbitrary order is at most a line
+    /// or two on the wrong side of a gap that has since narrowed.
+    fn applyContext(self: *Review) !void {
+        if (self.context.items.len == 0) return;
+        const p = self.parsed orelse return;
+        const arena = self.arena.allocator();
+
+        var i: usize = 0;
+        while (i < self.context.items.len) {
+            const c = &self.context.items[i];
+            const f = find(p.diff.files, c.path) orelse {
+                // The file is out of the review - committed, reverted, or now
+                // ignored. Keeping the entry would silently regrow it if it
+                // came back with different hunks.
+                self.gpa.free(c.path);
+                _ = self.context.swapRemove(i);
+                continue;
+            };
+            i += 1;
+            const work = self.buffersFor(c.path).work orelse continue;
+            if (c.hunk >= f.hunks.len) continue;
+            c.above = try expand_mod.grow(arena, f, work, c.hunk, .up, c.above);
+            c.below = try expand_mod.grow(arena, f, work, c.hunk, .down, c.below);
+        }
+    }
+
+    fn contextFor(self: *Review, path: []const u8, hi: u32) !*Context {
+        for (self.context.items) |*c| {
+            if (c.hunk == hi and std.mem.eql(u8, c.path, path)) return c;
+        }
+        const owned = try self.gpa.dupe(u8, path);
+        errdefer self.gpa.free(owned);
+        try self.context.append(self.gpa, .{ .path = owned, .hunk = hi });
+        return &self.context.items[self.context.items.len - 1];
     }
 
     /// Folds a file the reader opened. Returns false when it was not one -

--- a/src/ui/review.zig
+++ b/src/ui/review.zig
@@ -661,9 +661,59 @@ pub const Review = struct {
         return got;
     }
 
-    /// Forgets what a file had been grown by. The caller rebuilds; this only
-    /// stops the next re-diff from putting the context back, which is the same
-    /// shape `collapse` has.
+    /// Folds one hunk's context back to what git showed.
+    ///
+    /// One hunk and not the file, because `K` and `J` grow one hunk: a fold
+    /// key that closed every hunk in the file would throw away four other
+    /// windows the reader had opened and is standing nowhere near.
+    ///
+    /// Rebuilt from the git output this generation is already holding rather
+    /// than by running git again. Nothing about what git would say has
+    /// changed - only what the reader asked to see on top of it - so a
+    /// subprocess here would be a re-diff to undo a keystroke.
+    pub fn foldContext(self: *Review, path: []const u8, hi: u32) !bool {
+        if (!self.forget(path, hi)) return false;
+        return self.refold(path);
+    }
+
+    /// Folds every window in one file. What `zf` is: `zc` closes the one at
+    /// the cursor, and this closes the file's, for a reader who opened five
+    /// hunks and does not want to walk back to each of them.
+    pub fn foldAllContext(self: *Review, path: []const u8) !bool {
+        if (!self.collapseContext(path)) return false;
+        return self.refold(path);
+    }
+
+    /// Git's own answer for one file, from the output already in hand, with
+    /// whatever windows are still recorded reopened on top of it.
+    fn refold(self: *Review, path: []const u8) !bool {
+        const p = self.parsed orelse return false;
+        const f = find(p.diff.files, path) orelse return false;
+
+        const arena = self.arena.allocator();
+        // Kept before the parse replaces the slice: ids are inherited from it,
+        // and the hash matches every hunk exactly, because the only thing that
+        // changed is context and context is what the hash leaves out.
+        const prev = f.hunks;
+        if (!(diff.reparse(arena, f, p.raw) catch false)) return false;
+        try self.ids.inherit(arena, prev, f.hunks);
+
+        if (self.sources) |srcs| {
+            if (srcs.find(path)) |s| {
+                source.attach(f, s.*) catch |err| switch (err) {
+                    error.ContentMismatch => self.torn = true,
+                    else => return err,
+                };
+            }
+        }
+        // Any hunk of this file the reader did not fold kept its window, and
+        // the parse just took it away with everything else.
+        try self.applyContextTo(f);
+        return true;
+    }
+
+    /// Forgets every window into a file. Used by the paths that are throwing
+    /// the whole file away anyway - folding a large one, leaving the review.
     pub fn collapseContext(self: *Review, path: []const u8) bool {
         var found = false;
         var i: usize = 0;
@@ -677,6 +727,17 @@ pub const Review = struct {
             i += 1;
         }
         return found;
+    }
+
+    fn forget(self: *Review, path: []const u8, hi: u32) bool {
+        for (self.context.items, 0..) |c, i| {
+            if (c.hunk != hi or !std.mem.eql(u8, c.path, path)) continue;
+            if (c.above == 0 and c.below == 0) return false;
+            self.gpa.free(c.path);
+            _ = self.context.swapRemove(i);
+            return true;
+        }
+        return false;
     }
 
     /// Puts back what the reader had pulled out, on the generation that has
@@ -709,11 +770,24 @@ pub const Review = struct {
                 continue;
             };
             i += 1;
-            const work = self.buffersFor(c.path).work orelse continue;
-            if (c.hunk >= f.hunks.len) continue;
-            c.above = try expand_mod.grow(arena, f, work, c.hunk, .up, c.above);
-            c.below = try expand_mod.grow(arena, f, work, c.hunk, .down, c.below);
+            try self.regrow(arena, f, c);
         }
+    }
+
+    /// The same, for one file that has just been re-parsed under the reader.
+    fn applyContextTo(self: *Review, f: *diff.FileDiff) !void {
+        const arena = self.arena.allocator();
+        for (self.context.items) |*c| {
+            if (!std.mem.eql(u8, c.path, f.path())) continue;
+            try self.regrow(arena, f, c);
+        }
+    }
+
+    fn regrow(self: *Review, arena: Allocator, f: *diff.FileDiff, c: *Context) !void {
+        const work = self.buffersFor(c.path).work orelse return;
+        if (c.hunk >= f.hunks.len) return;
+        c.above = try expand_mod.grow(arena, f, work, c.hunk, .up, c.above);
+        c.below = try expand_mod.grow(arena, f, work, c.hunk, .down, c.below);
     }
 
     fn contextFor(self: *Review, path: []const u8, hi: u32) !*Context {

--- a/src/ui/rows.zig
+++ b/src/ui/rows.zig
@@ -167,6 +167,16 @@ pub const Rows = struct {
     }
 };
 
+/// Whether any new-file line between two consecutive hunks goes undrawn.
+///
+/// A hunk with no new-file lines - a pure deletion - sits between two lines
+/// rather than on one, so its last drawn line is `new_start` itself.
+fn hidesLines(prev: hunk.Hunk, next: hunk.Hunk) bool {
+    const prev_end = if (prev.new_count == 0) prev.new_start else prev.new_start + prev.new_count - 1;
+    const next_start = if (next.new_count == 0) next.new_start + 1 else next.new_start;
+    return next_start > prev_end + 1;
+}
+
 /// Width of the line-number column, from the largest number this file shows.
 pub fn numWidth(f: *const diff.FileDiff) u16 {
     var max: u32 = 1;
@@ -313,7 +323,10 @@ pub fn buildWith(
     }
 
     for (f.hunks, 0..) |h, hi| {
-        if (hi > 0) try b.items.append(gpa, .gap);
+        // The rule says lines are hidden here. Two hunks that context has
+        // grown until they touch have none between them, and drawing it there
+        // would be the chrome telling a lie about the file.
+        if (hi > 0 and hidesLines(f.hunks[hi - 1], h)) try b.items.append(gpa, .gap);
         try b.hunk_rows.append(gpa, @intCast(b.items.items.len));
         try b.items.append(gpa, .{ .hunk_header = @intCast(hi) });
         try b.body(h.lo, h.hi);
@@ -467,6 +480,43 @@ test "rows interleave headers, lines and one rule between hunks" {
     try testing.expect(rows.items[5] == .hunk_header);
     // No rule before the first hunk or after the last.
     try testing.expect(rows.items[rows.items.len - 1] == .line);
+}
+
+test "the rule between two hunks goes when nothing is hidden between them" {
+    const gpa = testing.allocator;
+    var f = try fixture(gpa);
+    defer freeFixture(gpa, &f);
+
+    // Context grown until the two meet: the first hunk now ends on line 8 and
+    // the second starts on 9, so there is nothing left for a rule to stand for.
+    f.hunks[0].new_count = 8;
+    f.hunks[0].old_count = 8;
+
+    var rows = try build(gpa, &f);
+    defer rows.deinit(gpa);
+
+    for (rows.items) |r| try testing.expect(r != .gap);
+    try testing.expect(rows.items[4] == .hunk_header);
+    // Both hunks are still hunks: the rule is chrome, not structure.
+    try testing.expectEqual(@as(usize, 2), rows.hunk_rows.len);
+}
+
+test "a pure deletion between two hunks still counts the line it sits on" {
+    const gpa = testing.allocator;
+    var f = try fixture(gpa);
+    defer freeFixture(gpa, &f);
+
+    // `@@ -9,1 +8,0 @@`: the deletion sits after new line 8, which the first
+    // hunk already ends on. Read as `new_start - 1` this would look like a
+    // hunk starting at 7 and overlapping the one before it.
+    f.hunks[0].new_count = 8;
+    f.hunks[0].old_count = 8;
+    f.hunks[1].new_start = 8;
+    f.hunks[1].new_count = 0;
+
+    var rows = try build(gpa, &f);
+    defer rows.deinit(gpa);
+    for (rows.items) |r| try testing.expect(r != .gap);
 }
 
 test "hunk lookup maps a cursor row to its hunk" {


### PR DESCRIPTION
#2 

- Expand hidden lines by J and K 
- You can fold expanded lines by `zc` (fold lines under your cursor and current context) , `zf` all expanded lines of the current file.
- Fix an issue with git while using `lgtm`
