### PR TITLE
feat: posting comments to a PR

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -142,8 +142,14 @@ ask_test      = "{ref}: a table test, not a unit test"
 | `ref_hunk` | `#{change_id} {path}:{line} (deleted lines in this hunk)` | the cursor on a removed line, which the new file has no number for |
 | `ref_file` | `{path}` | a file too large to render inline, so there is no hunk to point at |
 | `ref_file_line` / `_range` / `_span` | `{path}:{line}` … | a file with no hunks at all, opened and read rather than reviewed, so no `#id` |
+| `ref_prefix` | `PR #{pr} ` | put before every reference while a pull request is on screen, and nothing at all otherwise |
 | `submit_review` | `review ready: {path} ({count} comment{s})` | `path` `count` `s` |
 | `ask_why` `ask_revert` `ask_test` `ask_explain` | `{ref} - why this approach?` … | `ref`, whichever of the above the cursor produced |
+
+`ref_prefix` exists because a pull request is somebody else's tree.
+`src/config.zig:423` handed to an agent standing in your checkout points at
+different code, and nothing in the reference says so. Every `{var}` above is
+available to it, plus `{pr}`.
 
 `{s}` on `submit_review` is the plural: empty for one comment, `s` otherwise.
 It is a variable rather than a branch, because a template language with an `if`
@@ -308,7 +314,7 @@ way to check a spelling before committing it to a config file.
 
 **Comments** `comment_add` `comment_view` `comment_list` `comment_send`
 `comment_delete` `comment_send_one` `comment_send_all` `comment_drop`
-`comment_post_one`
+`comment_post_one` `compose_post_now`
 
 **Turns and the mark** `mark_here` `clear_mark` `next_fresh` `prev_fresh`
 `next_turn` `prev_turn` `turn_list` `restore_file` `undo_restore`

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -313,7 +313,7 @@ way to check a spelling before committing it to a config file.
 `copy_ref_lines` `submit_review`
 
 **Comments** `comment_add` `comment_view` `comment_list` `comment_send`
-`comment_delete` `comment_send_one` `comment_send_all` `comment_drop`
+`comment_delete` `comment_suggest` `comment_send_one` `comment_send_all` `comment_drop`
 `comment_post_one` `compose_post_now`
 
 **Turns and the mark** `mark_here` `clear_mark` `next_fresh` `prev_fresh`

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -308,6 +308,7 @@ way to check a spelling before committing it to a config file.
 
 **Comments** `comment_add` `comment_view` `comment_list` `comment_send`
 `comment_delete` `comment_send_one` `comment_send_all` `comment_drop`
+`comment_post_one`
 
 **Turns and the mark** `mark_here` `clear_mark` `next_fresh` `prev_fresh`
 `next_turn` `prev_turn` `turn_list` `restore_file` `undo_restore`

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -182,7 +182,9 @@ input box, never submitted, so you decide when to press return.
 - `y` yanks the selected *text*, the way `y` does in vim.
 
 **In the box:** `<Esc>` leaves insert for normal mode, where the same vim
-motions work and `o` opens a line; a second `<Esc>` leaves the box. `<C-i>`
+motions work and `o` opens a line; a second `<Esc>` leaves the box. Writing a
+comment, `<C-s>` saves it and sends it to your agent, and on a pull request
+`<C-p>` saves it and posts it, neither needing a trip through the list. `<C-i>`
 inserts a preset at the caret, `@` inserts a file path, `<C-j>` is a line break.
 Nothing you type is deleted by either.
 
@@ -195,7 +197,7 @@ A dozen remarks is a dozen interruptions, or it is one file.
 | `<Space>c` | write a comment on this line, on removed code too |
 | `]c` `[c` | walk them |
 | `<Space>vc` | open the nearest one to read or edit |
-| `<Space>lc` | list every comment; the filter reaches the file, the line and the text, and the panel beside the list shows the code the one you are on is about |
+| `<Space>lc` | list every comment; the panel beside the list shows the one you are on and the code it is about. The filter still reaches the text, even though the rows only show where each remark is |
 | `<Space>sc` | send just this one, now |
 | `<Space>dc` | delete the one here |
 | `<C-s>` | write `.lgtm/review-3.md` and tell the agent about it |
@@ -214,9 +216,9 @@ you type after the command becomes the review's opening sentence. In the list,
 `<C-p>` posts just the highlighted one, which is GitHub's "add single comment"
 beside its "submit review".
 
-The panel beside the list shows the hunk each remark sits in, not the remark
-itself: the row already carries that, and `<Space>vc` opens a long one to read
-whole.
+The rows are addresses, `path:line`, and the panel carries the remark itself
+followed by the hunk it sits in. A remark squeezed into a column is a remark
+you cannot read, so it is not in the column; typing part of one still finds it.
 
 Posting and sending are separate facts, so a remark can go to your agent *and*
 to the author, and neither hides it from the other. Posting a second time sends

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -181,10 +181,21 @@ input box, never submitted, so you decide when to press return.
 - `<Space>y` copies the reference to the clipboard instead of sending it.
 - `y` yanks the selected *text*, the way `y` does in vim.
 
-**In the box:** `<Esc>` leaves insert for normal mode, where the same vim
+**In the box:** `<C-o>` is a line break, mirroring the `o` that opens one in
+normal mode. `<C-j>` and `Shift-Enter` do the same where your terminal lets
+them through: a vim-tmux-navigator config binds `C-j` to move between panes, so
+tmux takes it before lgtm is asked. `<Esc>` leaves insert for normal mode, where the same vim
 motions work and `o` opens a line; a second `<Esc>` leaves the box. Writing a
 comment, `<C-s>` saves it and sends it to your agent, and on a pull request
-`<C-p>` saves it and posts it, neither needing a trip through the list. `<C-i>`
+`<C-p>` saves it and posts it, neither needing a trip through the list.
+
+If you write paragraphs more often than one-liners, swap the two:
+
+```toml
+[keys]
+compose_newline = ["<CR>", "<C-o>"]
+compose_submit  = ["<C-y>"]
+``` `<C-i>`
 inserts a preset at the caret, `@` inserts a file path, `<C-j>` is a line break.
 Nothing you type is deleted by either.
 
@@ -523,7 +534,7 @@ filters. `<Tab>` and `<S-Tab>`, the arrow keys, and `<C-n>`/`<C-p>` all move too
 ### In the compose box
 
 `<Esc>` leaves insert then leaves the box, `<CR>` sends, `<C-i>` inserts a
-preset, `@` inserts a file path, `<C-j>` is a line break, `<C-s>` saves a
+preset, `@` inserts a file path, `<C-o>` is a line break, `<C-s>` saves a
 comment and sends it at once. In normal mode: the review's motions plus
 `i a I A o O x D C dd cc d{motion} c{motion} u`.
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -205,7 +205,9 @@ A dozen remarks is a dozen interruptions, or it is one file.
 
 | | |
 |---|---|
-| `<Space>c` | write a comment on this line, on removed code too |
+| `<Space>c` | write a comment on this line, on removed code too. With `v` or `V` selecting more than one, the comment covers all of them |
+| `<Space>gc` | suggest a change: a comment already holding the selected lines in a ```suggestion block |
+| | the box's title says what the comment covers: `a.txt:5` for one line, `a.txt:5-6` for a range |
 | `]c` `[c` | walk them |
 | `<Space>vc` | open the nearest one to read or edit |
 | `<Space>lc` | list every comment; the panel beside the list shows the one you are on and the code it is about. The filter still reaches the text, even though the rows only show where each remark is |
@@ -226,6 +228,19 @@ hands the collected ones to the request as one review; `:approve` and
 you type after the command becomes the review's opening sentence. In the list,
 `<C-p>` posts just the highlighted one, which is GitHub's "add single comment"
 beside its "submit review".
+
+A selection can only cover lines the new file still has, so selecting a
+removed line together with the one that replaced it gives a remark on the
+replacement alone. Nothing can be suggested for a line that is gone. The box's
+title is where you see what you actually got.
+
+A comment made over a selection covers every line it touches, `v` or `V`
+alike: a remark anchors to whole lines, so where in them the selection starts
+makes no difference. And `<Space>gc`
+opens one already holding those lines inside a ```suggestion fence, so you edit
+the code rather than describe the edit. Posted to a pull request it becomes a
+real suggestion the author applies with one click, and GitHub needs the range
+for that: a three-line replacement has to be anchored to three lines.
 
 The rows are addresses, `path:line`, and the panel carries the remark itself
 followed by the hunk it sits in. A remark squeezed into a column is a remark
@@ -389,8 +404,8 @@ documents itself. What follows is the defaults.
 
 | Key | |
 |---|---|
-| `j` `k` | down and up a line |
-| `h` `l` | left and right a character |
+| `j` `k` | down and up a line, and so do the arrows |
+| `h` `l` | left and right a character, and so do the arrows |
 | `w` `b` `e` | next, previous, end of word |
 | `W` `B` `E` | the same over WORDs, where only blanks separate |
 | `0` `^` `$` | first, first non-blank, last column |
@@ -535,7 +550,9 @@ filters. `<Tab>` and `<S-Tab>`, the arrow keys, and `<C-n>`/`<C-p>` all move too
 
 `<Esc>` leaves insert then leaves the box, `<CR>` sends, `<C-i>` inserts a
 preset, `@` inserts a file path, `<C-o>` is a line break, `<C-s>` saves a
-comment and sends it at once. In normal mode: the review's motions plus
+comment and sends it at once, and on a pull request `<C-p>` saves and posts it.
+The arrows move a line at a time; `<C-a>` `<C-e>` `<C-b>` `<C-f>` `<C-u>`
+`<C-w>` `<C-d>` are readline's. In normal mode: the review's motions plus
 `i a I A o O x D C dd cc d{motion} c{motion} u`.
 
 ---

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -195,7 +195,7 @@ A dozen remarks is a dozen interruptions, or it is one file.
 | `<Space>c` | write a comment on this line, on removed code too |
 | `]c` `[c` | walk them |
 | `<Space>vc` | open the nearest one to read or edit |
-| `<Space>lc` | list every comment; the filter reaches the file, the line and the text, and the panel beside the list shows the one you are on as you wrote it |
+| `<Space>lc` | list every comment; the filter reaches the file, the line and the text, and the panel beside the list shows the code the one you are on is about |
 | `<Space>sc` | send just this one, now |
 | `<Space>dc` | delete the one here |
 | `<C-s>` | write `.lgtm/review-3.md` and tell the agent about it |
@@ -204,7 +204,40 @@ Comments follow the code when the agent rewrites it, survive a restart, and say
 so when they can no longer be placed. A comment is never silently dropped.
 
 In the comment list, `<C-s>` sends the highlighted one, `<C-x>` sends every open
-one as the review file, `<C-d>` deletes one.
+one as the review file, `<C-d>` deletes one. `J K` move and `H L` page, as in
+every list; the footer names only the keys you could not guess.
+
+**Reviewing a pull request, the same comments have a second home.** `:post`
+hands the collected ones to the request as one review; `:approve` and
+`:request-changes` are the same batch with a different verdict, and anything
+you type after the command becomes the review's opening sentence. In the list,
+`<C-p>` posts just the highlighted one, which is GitHub's "add single comment"
+beside its "submit review".
+
+The panel beside the list shows the hunk each remark sits in, not the remark
+itself: the row already carries that, and `<Space>vc` opens a long one to read
+whole.
+
+Posting and sending are separate facts, so a remark can go to your agent *and*
+to the author, and neither hides it from the other. Posting a second time sends
+only what is new. A remark GitHub cannot attach to a line, one that went stale
+or that sits outside the diff, travels in the review's body with its file and
+line rather than being dropped.
+
+Comments are kept per review: those written on `--pr 16` live in
+`.lgtm/pr-16.jsonl` and appear only while you are reviewing #16. Your working
+tree keeps its own in `.lgtm/comments.jsonl`.
+
+What the agent is told changes too. A pull request is somebody else's tree, so
+`src/config.zig:8` means nothing in your checkout; the review file opens by
+naming the request and how to get it:
+
+```markdown
+# Review 1
+
+> Pull request #16, kunkka19xx/lgtm. Line numbers are that tree, not the
+> working one: `gh pr checkout 16`.
+```
 
 ### 4. Come back to what's new
 
@@ -432,6 +465,7 @@ A second `,` keeps going back rather than turning round, the way vim's does.
 | `?` | every key, from your bindings |
 | `:` | run any command by name, `<Tab>` completes (see below) |
 | `:pr [n]` | review a pull request without restarting; bare, the current branch's. `:pr off` comes back to the working tree |
+| `:post` `:approve` `:request-changes` | hand the collected comments to the pull request, as one review |
 | `:q` | quit |
 
 ### The command line
@@ -500,7 +534,8 @@ review with its own `.gitignore`:
 
 | | |
 |---|---|
-| `.lgtm/comments.jsonl` | your comments |
+| `.lgtm/comments.jsonl` | your comments on the working tree |
+| `.lgtm/pr-N.jsonl` | your comments on pull request N |
 | `.lgtm/review-N.md` | what `<C-s>` wrote |
 | `.lgtm/state.json` | the session, the turn count, where you read to |
 | `.lgtm/config.toml` | this repository's settings, if you commit one |

--- a/src/bridge/template.zig
+++ b/src/bridge/template.zig
@@ -36,6 +36,14 @@ pub const Table = struct {
     ref_file_range: []const u8 = "{path}:{start}-{end}",
     ref_file_span: []const u8 = "{path}:{line} `{span}`",
 
+    /// Put in front of every reference while a pull request is on screen.
+    ///
+    /// `src/config.zig:423` is a line of somebody else's tree, and an agent
+    /// standing in the working tree resolves it against different code without
+    /// anything saying so. Empty in a working-tree review, where the reference
+    /// already means what it says.
+    ref_prefix: []const u8 = "PR #{pr} ",
+
     /// Handing over a whole review: the file that was written, and how many
     /// remarks are in it.
     ///
@@ -108,6 +116,19 @@ fn expand(tmpl: []const u8, vars: []const Var) ![]u8 {
     errdefer out.deinit(testing.allocator);
     try render(testing.allocator, &out, tmpl, vars);
     return out.toOwnedSlice(testing.allocator);
+}
+
+test "a reference to a pull request says which one" {
+    const got = try expand(default.ref_prefix ++ default.ref_single, &.{
+        .{ .name = "pr", .value = "16" },
+        .{ .name = "change_id", .value = "3" },
+        .{ .name = "path", .value = "src/config.zig" },
+        .{ .name = "line", .value = "423" },
+    });
+    defer testing.allocator.free(got);
+    // Without it the agent reads a line number against the tree it is
+    // standing in, which is different code.
+    try testing.expectEqualStrings("PR #16 #3 src/config.zig:423", got);
 }
 
 test "the review handover is a template like everything else" {

--- a/src/core/comments.zig
+++ b/src/core/comments.zig
@@ -57,6 +57,9 @@ pub const Comment = struct {
     path: []const u8,
     /// 1-based line in the working tree. Carried forward on every re-diff.
     line: u32,
+    /// Lines the remark covers, one being just `line`. A count and not an end
+    /// line: re-anchoring moves one number and the span comes with it.
+    span: u32 = 1,
     /// What the reader wrote. Owned, and may contain newlines - it is written
     /// to a file, not sent through `send-keys` (hard rule 1 is about the
     /// bridge, and `review.zig` sends one line naming the file).
@@ -78,6 +81,10 @@ pub const Comment = struct {
     /// *agent* has seen it: a remark legitimately goes to both audiences, and
     /// one field for two would make either destination skip the other's work.
     posted: bool = false,
+
+    pub fn end(self: Comment) u32 {
+        return self.line + @max(self.span, 1) - 1;
+    }
 
     pub fn deinit(self: Comment, gpa: Allocator) void {
         gpa.free(self.path);
@@ -132,7 +139,7 @@ pub const Store = struct {
         body: []const u8,
         anchor_text: []const u8,
     ) Allocator.Error!u32 {
-        return self.addFull(path, line, body, anchor_text, false);
+        return self.addFull(path, line, body, anchor_text, false, 1);
     }
 
     pub fn addFull(
@@ -142,6 +149,7 @@ pub const Store = struct {
         body: []const u8,
         anchor_text: []const u8,
         about_removed: bool,
+        span: u32,
     ) Allocator.Error!u32 {
         const p = try self.gpa.dupe(u8, path);
         errdefer self.gpa.free(p);
@@ -151,7 +159,7 @@ pub const Store = struct {
         errdefer self.gpa.free(a);
 
         const id = self.next_id;
-        try self.list.append(self.gpa, .{ .id = id, .path = p, .line = line, .body = b, .anchor = a, .about_removed = about_removed });
+        try self.list.append(self.gpa, .{ .id = id, .path = p, .line = line, .span = @max(span, 1), .body = b, .anchor = a, .about_removed = about_removed });
         self.next_id += 1;
         self.dirty = true;
         return id;
@@ -312,6 +320,10 @@ pub fn write(out: *std.ArrayList(u8), gpa: Allocator, store: *const Store) Alloc
         try out.appendSlice(gpa, "\",\"path\":");
         try quoteJson(out, gpa, n.path);
         if (n.about_removed) try out.appendSlice(gpa, ",\"removed\":true");
+        if (n.span > 1) {
+            try out.appendSlice(gpa, ",\"span\":");
+            try out.appendSlice(gpa, std.fmt.bufPrint(&num, "{d}", .{n.span}) catch "1");
+        }
         if (n.posted) try out.appendSlice(gpa, ",\"posted\":true");
         try out.appendSlice(gpa, ",\"anchor\":");
         try quoteJson(out, gpa, n.anchor);
@@ -341,12 +353,13 @@ pub fn read(store: *Store, text: []const u8) Allocator.Error!void {
         const a = if (string(line, "\"anchor\":")) |raw| unquote(&buf_anchor, raw) else "";
 
         const removed = std.mem.indexOf(u8, line, "\"removed\":true") != null;
-        const new_id = try store.addFull(p, @intCast(ln), b, a, removed);
+        const new_id = try store.addFull(p, @intCast(ln), b, a, removed, 1);
         const n = store.find(new_id).?;
         n.id = @intCast(id);
         if (std.mem.indexOf(u8, line, "\"state\":\"sent\"") != null) n.state = .sent;
         if (std.mem.indexOf(u8, line, "\"state\":\"stale\"") != null) n.state = .stale;
         n.posted = std.mem.indexOf(u8, line, "\"posted\":true") != null;
+        if (field(line, "\"span\":")) |sp| n.span = @max(1, @as(u32, @intCast(sp)));
         if (store.next_id <= n.id) store.next_id = n.id + 1;
     }
     store.dirty = false;

--- a/src/core/comments.zig
+++ b/src/core/comments.zig
@@ -74,6 +74,10 @@ pub const Comment = struct {
     /// the nearest surviving line of its hunk, and this is what stops that
     /// from reading as a remark about the code it landed next to.
     about_removed: bool = false,
+    /// Handed to the forge. Separate from `state`, which says whether the
+    /// *agent* has seen it: a remark legitimately goes to both audiences, and
+    /// one field for two would make either destination skip the other's work.
+    posted: bool = false,
 
     pub fn deinit(self: Comment, gpa: Allocator) void {
         gpa.free(self.path);
@@ -191,6 +195,17 @@ pub const Store = struct {
 
     /// Marks every open comment as sent. Called after a review file is written,
     /// because that is the moment the agent has them.
+    /// Marks every comment `ids` names as handed to the forge.
+    pub fn markPosted(self: *Store, ids: []const u32) void {
+        for (self.list.items) |*n| {
+            for (ids) |id| {
+                if (n.id != id) continue;
+                if (!n.posted) self.dirty = true;
+                n.posted = true;
+            }
+        }
+    }
+
     pub fn markSent(self: *Store) void {
         for (self.list.items) |*n| {
             if (n.state == .open) n.state = .sent;
@@ -295,12 +310,13 @@ pub fn write(out: *std.ArrayList(u8), gpa: Allocator, store: *const Store) Alloc
         try out.appendSlice(gpa, ",\"state\":\"");
         try out.appendSlice(gpa, n.state.name());
         try out.appendSlice(gpa, "\",\"path\":");
-        try quote(out, gpa, n.path);
+        try quoteJson(out, gpa, n.path);
         if (n.about_removed) try out.appendSlice(gpa, ",\"removed\":true");
+        if (n.posted) try out.appendSlice(gpa, ",\"posted\":true");
         try out.appendSlice(gpa, ",\"anchor\":");
-        try quote(out, gpa, n.anchor);
+        try quoteJson(out, gpa, n.anchor);
         try out.appendSlice(gpa, ",\"body\":");
-        try quote(out, gpa, n.body);
+        try quoteJson(out, gpa, n.body);
         try out.appendSlice(gpa, "}\n");
     }
 }
@@ -330,12 +346,15 @@ pub fn read(store: *Store, text: []const u8) Allocator.Error!void {
         n.id = @intCast(id);
         if (std.mem.indexOf(u8, line, "\"state\":\"sent\"") != null) n.state = .sent;
         if (std.mem.indexOf(u8, line, "\"state\":\"stale\"") != null) n.state = .stale;
+        n.posted = std.mem.indexOf(u8, line, "\"posted\":true") != null;
         if (store.next_id <= n.id) store.next_id = n.id + 1;
     }
     store.dirty = false;
 }
 
-fn quote(out: *std.ArrayList(u8), gpa: Allocator, text: []const u8) Allocator.Error!void {
+/// A JSON string literal. Shared with `core/gh.zig`, which builds a review
+/// out of the same bytes this stores.
+pub fn quoteJson(out: *std.ArrayList(u8), gpa: Allocator, text: []const u8) Allocator.Error!void {
     try out.append(gpa, '"');
     for (text) |ch| switch (ch) {
         '"' => try out.appendSlice(gpa, "\\\""),

--- a/src/core/gh.zig
+++ b/src/core/gh.zig
@@ -16,6 +16,9 @@
 const std = @import("std");
 const Allocator = std.mem.Allocator;
 
+const comments = @import("comments.zig");
+const diff = @import("diff.zig");
+const hunk = @import("hunk.zig");
 const git = @import("git.zig");
 const proc = @import("../io/proc.zig");
 
@@ -97,6 +100,8 @@ pub fn view(gpa: Allocator, arena: Allocator, io: std.Io, number: ?u32) Error!Pr
 /// A pull request as two refs. The whole of what GitHub is asked for.
 pub const Refs = struct {
     number: u32,
+    /// `owner/repo`, kept so posting a review needs no second question.
+    repo: []const u8,
     /// The merge base, which is what a three-dot diff is taken against.
     base: []const u8,
     /// The head commit.
@@ -166,10 +171,121 @@ pub fn resolve(
 
     return .{
         .number = pr.number,
+        .repo = ownerRepo(pr.url) orelse "",
         .base = base,
         .target = try arena.dupe(u8, pr.head_oid),
         .label = try std.fmt.allocPrint(arena, "#{d} {s}", .{ pr.number, pr.title }),
     };
+}
+
+/// What a review says when it is submitted.
+pub const Event = enum {
+    comment,
+    approve,
+    request_changes,
+
+    pub fn wire(self: Event) []const u8 {
+        return switch (self) {
+            .comment => "COMMENT",
+            .approve => "APPROVE",
+            .request_changes => "REQUEST_CHANGES",
+        };
+    }
+};
+
+/// Whether a comment can be attached to a line of the diff.
+///
+/// GitHub takes an inline comment only on a line inside a hunk; anything else
+/// is a 422. A remark that cannot be placed is not dropped, it goes into the
+/// review body with its file and line, which is hard rule 7 pointed at a
+/// second destination.
+pub fn inlineable(files: []const diff.FileDiff, path: []const u8, line: u32) bool {
+    for (files) |f| {
+        if (!std.mem.eql(u8, f.path(), path)) continue;
+        for (f.hunks) |h| {
+            if (h.overlapsNew(line, 1) > 0) return true;
+        }
+        return false;
+    }
+    return false;
+}
+
+/// The review body and its inline comments, as the API wants them.
+///
+/// One request, so a partial failure cannot happen: either the whole review
+/// lands or none of it does.
+pub fn reviewBody(
+    out: *std.ArrayList(u8),
+    gpa: Allocator,
+    store: *const comments.Store,
+    files: []const diff.FileDiff,
+    event: Event,
+    note: []const u8,
+    /// Filled with the ids that went inline or into the body, so the caller
+    /// can mark exactly what was handed over.
+    ids: *std.ArrayList(u32),
+) Allocator.Error!void {
+    var body: std.ArrayList(u8) = .empty;
+    defer body.deinit(gpa);
+    if (note.len > 0) try body.appendSlice(gpa, note);
+
+    var inlines: std.ArrayList(u8) = .empty;
+    defer inlines.deinit(gpa);
+
+    for (store.items()) |n| {
+        if (n.posted) continue;
+        try ids.append(gpa, n.id);
+
+        if (n.state != .stale and inlineable(files, n.path, n.line)) {
+            if (inlines.items.len > 0) try inlines.append(gpa, ',');
+            try inlines.appendSlice(gpa, "{\"path\":");
+            try comments.quoteJson(&inlines, gpa, n.path);
+            // Always the right-hand side. A comment on removed code hangs on
+            // the nearest surviving line and no old line number is kept, so
+            // `LEFT` has nothing to anchor to; the body below says what it was
+            // about instead.
+            try inlines.print(gpa, ",\"line\":{d},\"side\":\"RIGHT\",\"body\":", .{n.line});
+            try comments.quoteJson(&inlines, gpa, n.body);
+            try inlines.append(gpa, '}');
+            continue;
+        }
+
+        // Not placeable: stale, or anchored outside every hunk.
+        if (body.items.len > 0) try body.appendSlice(gpa, "\n\n");
+        try body.print(gpa, "**{s}:{d}**", .{ n.path, n.line });
+        if (n.state == .stale) try body.appendSlice(gpa, " _(the line this was written against has gone)_");
+        if (n.about_removed) try body.appendSlice(gpa, " _(about code removed here)_");
+        try body.appendSlice(gpa, "\n\n");
+        try body.appendSlice(gpa, n.body);
+    }
+
+    try out.appendSlice(gpa, "{\"event\":\"");
+    try out.appendSlice(gpa, event.wire());
+    try out.appendSlice(gpa, "\",\"body\":");
+    try comments.quoteJson(out, gpa, body.items);
+    try out.appendSlice(gpa, ",\"comments\":[");
+    try out.appendSlice(gpa, inlines.items);
+    try out.appendSlice(gpa, "]}");
+}
+
+/// `gh api repos/{owner}/{repo}/pulls/{n}/reviews --input -`
+pub fn postArgv(arena: Allocator, repo: []const u8, number: u32) Allocator.Error![]const []const u8 {
+    const path = try std.fmt.allocPrint(arena, "repos/{s}/pulls/{d}/reviews", .{ repo, number });
+    return arena.dupe([]const u8, &.{ "gh", "api", "--method", "POST", path, "--input", "-" });
+}
+
+pub fn post(
+    gpa: Allocator,
+    arena: Allocator,
+    io: std.Io,
+    repo: []const u8,
+    number: u32,
+    payload: []const u8,
+) Error!void {
+    const argv = try postArgv(arena, repo, number);
+    const out = proc.runWithInput(gpa, io, argv, payload, view_output_max) catch return error.GhFailed;
+    defer out.deinit(gpa);
+    if (out.exit_code != 0) return error.GhFailed;
 }
 
 const testing = std.testing;
@@ -218,6 +334,75 @@ test "the owning repository is read out of the address, not asked for again" {
     // answer is a repository because nothing has to - it is matched against
     // the remotes, and one that matches none falls back to `origin`.
     try testing.expectEqualStrings("github.com/lgtm", ownerRepo("https://github.com/lgtm/pull/13").?);
+}
+
+fn oneFile(path: []const u8, hunks: []hunk.Hunk) diff.FileDiff {
+    return .{ .old_path = path, .new_path = path, .status = .modified, .hunks = hunks };
+}
+
+test "a review carries what can be placed inline and says the rest in its body" {
+    const gpa = testing.allocator;
+    var store: comments.Store = .init(gpa);
+    defer store.deinit();
+
+    _ = try store.add("a.zig", 47, "the retry loop never backs off");
+    _ = try store.add("a.zig", 900, "nowhere near a hunk");
+    const gone = try store.add("a.zig", 12, "this line is gone");
+    store.find(gone).?.state = .stale;
+
+    var hunks = [_]hunk.Hunk{.{ .old_start = 40, .old_count = 10, .new_start = 40, .new_count = 10, .lo = 0, .hi = 0 }};
+    var files = [_]diff.FileDiff{oneFile("a.zig", &hunks)};
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(gpa);
+    var ids: std.ArrayList(u32) = .empty;
+    defer ids.deinit(gpa);
+    try reviewBody(&out, gpa, &store, &files, .request_changes, "two things", &ids);
+
+    try testing.expect(std.mem.indexOf(u8, out.items, "\"event\":\"REQUEST_CHANGES\"") != null);
+    // Inside a hunk: an inline comment on the right-hand side.
+    try testing.expect(std.mem.indexOf(u8, out.items, "\"line\":47,\"side\":\"RIGHT\"") != null);
+    // Outside every hunk, and stale: both in the body with their line, never
+    // dropped. GitHub would reject them inline with a 422.
+    try testing.expect(std.mem.indexOf(u8, out.items, "a.zig:900") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "a.zig:12") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "has gone") != null);
+    // The covering note leads.
+    try testing.expect(std.mem.indexOf(u8, out.items, "two things") != null);
+    // Every remark is accounted for, so the caller marks exactly what went.
+    try testing.expectEqual(@as(usize, 3), ids.items.len);
+}
+
+test "a remark already posted is not posted twice" {
+    const gpa = testing.allocator;
+    var store: comments.Store = .init(gpa);
+    defer store.deinit();
+
+    const id = try store.add("a.zig", 47, "said once");
+    var hunks = [_]hunk.Hunk{.{ .old_start = 40, .old_count = 10, .new_start = 40, .new_count = 10, .lo = 0, .hi = 0 }};
+    var files = [_]diff.FileDiff{oneFile("a.zig", &hunks)};
+
+    store.markPosted(&.{id});
+    // `posted` is its own fact: handing a remark to the agent must not stop it
+    // reaching the author, or the reverse.
+    store.find(id).?.state = .sent;
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(gpa);
+    var ids: std.ArrayList(u32) = .empty;
+    defer ids.deinit(gpa);
+    try reviewBody(&out, gpa, &store, &files, .comment, "", &ids);
+    try testing.expectEqual(@as(usize, 0), ids.items.len);
+    try testing.expect(std.mem.indexOf(u8, out.items, "said once") == null);
+}
+
+test "posting goes to the repository the request is on" {
+    var a: std.heap.ArenaAllocator = .init(testing.allocator);
+    defer a.deinit();
+    const argv = try postArgv(a.allocator(), "kunkka19xx/lgtm", 13);
+    try testing.expectEqualStrings("repos/kunkka19xx/lgtm/pulls/13/reviews", argv[4]);
+    try testing.expectEqualStrings("--input", argv[5]);
+    try testing.expectEqualStrings("-", argv[6]);
 }
 
 test "a head is fetched from the ref the forge puts it at" {

--- a/src/core/gh.zig
+++ b/src/core/gh.zig
@@ -199,11 +199,14 @@ pub const Event = enum {
 /// is a 422. A remark that cannot be placed is not dropped, it goes into the
 /// review body with its file and line, which is hard rule 7 pointed at a
 /// second destination.
-pub fn inlineable(files: []const diff.FileDiff, path: []const u8, line: u32) bool {
+pub fn inlineable(files: []const diff.FileDiff, path: []const u8, line: u32, span: u32) bool {
+    const n = @max(span, 1);
     for (files) |f| {
         if (!std.mem.eql(u8, f.path(), path)) continue;
+        // Wholly inside one hunk, not merely touching one: a range across a
+        // gap covers lines the diff does not show, and that is a 422.
         for (f.hunks) |h| {
-            if (h.overlapsNew(line, 1) > 0) return true;
+            if (h.overlapsNew(line, n) == n) return true;
         }
         return false;
     }
@@ -236,15 +239,18 @@ pub fn reviewBody(
         if (n.posted) continue;
         try ids.append(gpa, n.id);
 
-        if (n.state != .stale and inlineable(files, n.path, n.line)) {
+        if (n.state != .stale and inlineable(files, n.path, n.line, n.span)) {
             if (inlines.items.len > 0) try inlines.append(gpa, ',');
             try inlines.appendSlice(gpa, "{\"path\":");
             try comments.quoteJson(&inlines, gpa, n.path);
+            // Both ends, which is what a multi-line `suggestion` replaces:
+            // three lines out needs three lines in.
+            if (n.span > 1) try inlines.print(gpa, ",\"start_line\":{d},\"start_side\":\"RIGHT\"", .{n.line});
             // Always the right-hand side. A comment on removed code hangs on
             // the nearest surviving line and no old line number is kept, so
             // `LEFT` has nothing to anchor to; the body below says what it was
             // about instead.
-            try inlines.print(gpa, ",\"line\":{d},\"side\":\"RIGHT\",\"body\":", .{n.line});
+            try inlines.print(gpa, ",\"line\":{d},\"side\":\"RIGHT\",\"body\":", .{n.end()});
             try comments.quoteJson(&inlines, gpa, n.body);
             try inlines.append(gpa, '}');
             continue;
@@ -252,7 +258,11 @@ pub fn reviewBody(
 
         // Not placeable: stale, or anchored outside every hunk.
         if (body.items.len > 0) try body.appendSlice(gpa, "\n\n");
-        try body.print(gpa, "**{s}:{d}**", .{ n.path, n.line });
+        if (n.span > 1) {
+            try body.print(gpa, "**{s}:{d}-{d}**", .{ n.path, n.line, n.end() });
+        } else {
+            try body.print(gpa, "**{s}:{d}**", .{ n.path, n.line });
+        }
         if (n.state == .stale) try body.appendSlice(gpa, " _(the line this was written against has gone)_");
         if (n.about_removed) try body.appendSlice(gpa, " _(about code removed here)_");
         try body.appendSlice(gpa, "\n\n");
@@ -371,6 +381,59 @@ test "a review carries what can be placed inline and says the rest in its body" 
     try testing.expect(std.mem.indexOf(u8, out.items, "two things") != null);
     // Every remark is accounted for, so the caller marks exactly what went.
     try testing.expectEqual(@as(usize, 3), ids.items.len);
+}
+
+test "a range is anchored at both ends, and only inside one hunk" {
+    const gpa = testing.allocator;
+    var store: comments.Store = .init(gpa);
+    defer store.deinit();
+
+    const three = try store.addFull("a.zig", 44, "```suggestion\nnew\n```", "", false, 3);
+    _ = three;
+    // Straddles the gap between two hunks, so no range can hold it.
+    _ = try store.addFull("a.zig", 48, "spans a gap", "", false, 10);
+
+    var hunks = [_]hunk.Hunk{
+        .{ .old_start = 44, .old_count = 6, .new_start = 44, .new_count = 6, .lo = 0, .hi = 0 },
+        .{ .old_start = 90, .old_count = 4, .new_start = 90, .new_count = 4, .lo = 0, .hi = 0 },
+    };
+    var files = [_]diff.FileDiff{oneFile("a.zig", &hunks)};
+
+    // Whole range inside one hunk, or not at all: a range over lines the diff
+    // does not show is a 422.
+    try testing.expect(inlineable(&files, "a.zig", 44, 3));
+    try testing.expect(!inlineable(&files, "a.zig", 48, 10));
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(gpa);
+    var ids: std.ArrayList(u32) = .empty;
+    defer ids.deinit(gpa);
+    try reviewBody(&out, gpa, &store, &files, .comment, "", &ids);
+
+    // Both ends, and `line` is the last of them: the suggestion replaces 44
+    // through 46.
+    try testing.expect(std.mem.indexOf(u8, out.items, "\"start_line\":44,\"start_side\":\"RIGHT\"") != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "\"line\":46,\"side\":\"RIGHT\"") != null);
+    // The one that cannot be placed says its whole range in the body.
+    try testing.expect(std.mem.indexOf(u8, out.items, "a.zig:48-57") != null);
+}
+
+test "a single-line remark still sends one anchor" {
+    const gpa = testing.allocator;
+    var store: comments.Store = .init(gpa);
+    defer store.deinit();
+    _ = try store.add("a.zig", 44, "just here");
+
+    var hunks = [_]hunk.Hunk{.{ .old_start = 44, .old_count = 6, .new_start = 44, .new_count = 6, .lo = 0, .hi = 0 }};
+    var files = [_]diff.FileDiff{oneFile("a.zig", &hunks)};
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(gpa);
+    var ids: std.ArrayList(u32) = .empty;
+    defer ids.deinit(gpa);
+    try reviewBody(&out, gpa, &store, &files, .comment, "", &ids);
+    try testing.expect(std.mem.indexOf(u8, out.items, "start_line") == null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "\"line\":44") != null);
 }
 
 test "a remark already posted is not posted twice" {

--- a/src/core/review.zig
+++ b/src/core/review.zig
@@ -41,11 +41,28 @@ pub fn path(buf: []u8, n: u32) []const u8 {
 /// is still something the reader wrote and has not dismissed, so it goes in
 /// with a warning rather than being dropped on its way to the agent. Hard rule
 /// 7 does not stop at the screen.
-pub fn render(out: *std.ArrayList(u8), gpa: Allocator, store: *const comments.Store, n: u32) Allocator.Error!u32 {
+/// `scope` says what the line numbers below belong to, and is empty for the
+/// working tree, where they belong to the files on disk.
+///
+/// A review of a pull request is a review of somebody else's tree. Without
+/// this the agent reads `src/config.zig:8` and looks at line 8 of the checkout
+/// it is standing in, which is different code, and nothing says so.
+pub fn render(
+    out: *std.ArrayList(u8),
+    gpa: Allocator,
+    store: *const comments.Store,
+    n: u32,
+    scope: []const u8,
+) Allocator.Error!u32 {
     var num: [24]u8 = undefined;
     try out.appendSlice(gpa, "# Review ");
     try out.appendSlice(gpa, std.fmt.bufPrint(&num, "{d}", .{n}) catch "");
     try out.appendSlice(gpa, "\n");
+    if (scope.len > 0) {
+        try out.appendSlice(gpa, "\n> ");
+        try out.appendSlice(gpa, scope);
+        try out.appendSlice(gpa, "\n");
+    }
 
     var written: u32 = 0;
     // Files in first-appearance order, without allocating a set: the comment
@@ -118,6 +135,30 @@ fn indent(out: *std.ArrayList(u8), gpa: Allocator, body: []const u8) Allocator.E
     }
 }
 
+test "a review of somebody else's tree says whose" {
+    var store: comments.Store = .init(testing.allocator);
+    defer store.deinit();
+    _ = try store.add("src/config.zig", 8, "this list should be sorted");
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    const scope = "Pull request #16, kunkka19xx/lgtm. Line numbers are that tree: `gh pr checkout 16`.";
+    _ = try render(&out, testing.allocator, &store, 1, scope);
+
+    // Without it the agent reads `src/config.zig:8` and looks at line 8 of the
+    // checkout it is standing in, which is different code.
+    try testing.expect(std.mem.indexOf(u8, out.items, scope) != null);
+    try testing.expect(std.mem.indexOf(u8, out.items, "gh pr checkout 16") != null);
+
+    // A working-tree review says nothing extra: the lines are the files.
+    // (`>` alone would not tell us, since every body is a blockquote.)
+    var plain: std.ArrayList(u8) = .empty;
+    defer plain.deinit(testing.allocator);
+    _ = try render(&plain, testing.allocator, &store, 1, "");
+    try testing.expect(std.mem.indexOf(u8, plain.items, "Pull request") == null);
+    try testing.expect(std.mem.startsWith(u8, plain.items, "# Review 1\n\n## "));
+}
+
 const testing = std.testing;
 
 test "the review groups by file and orders by line" {
@@ -130,7 +171,7 @@ test "the review groups by file and orders by line" {
 
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(testing.allocator);
-    const n = try render(&out, testing.allocator, &store, 3);
+    const n = try render(&out, testing.allocator, &store, 3, "");
     try testing.expectEqual(@as(u32, 3), n);
 
     const text = out.items;
@@ -153,7 +194,7 @@ test "sent comments stay out, so nothing is asked for twice" {
 
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(testing.allocator);
-    const n = try render(&out, testing.allocator, &store, 1);
+    const n = try render(&out, testing.allocator, &store, 1, "");
     try testing.expectEqual(@as(u32, 1), n);
     try testing.expect(std.mem.indexOf(u8, out.items, "already said this") == null);
     try testing.expect(std.mem.indexOf(u8, out.items, "this one is new") != null);
@@ -169,7 +210,7 @@ test "a stale comment says so in the file, not just on screen" {
 
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(testing.allocator);
-    _ = try render(&out, testing.allocator, &store, 1);
+    _ = try render(&out, testing.allocator, &store, 1, "");
     try testing.expect(std.mem.indexOf(u8, out.items, "stale") != null);
     try testing.expect(std.mem.indexOf(u8, out.items, "this branch is dead") != null);
 }
@@ -181,7 +222,7 @@ test "a multi-line note stays inside its bullet" {
 
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(testing.allocator);
-    _ = try render(&out, testing.allocator, &store, 1);
+    _ = try render(&out, testing.allocator, &store, 1, "");
     // Every line of the body is quoted, so a list inside a comment does not
     // become a sibling of the bullet it belongs to.
     try testing.expect(std.mem.indexOf(u8, out.items, "  > - because") != null);
@@ -194,7 +235,7 @@ test "an empty review says so rather than being a bare heading" {
 
     var out: std.ArrayList(u8) = .empty;
     defer out.deinit(testing.allocator);
-    try testing.expectEqual(@as(u32, 0), try render(&out, testing.allocator, &store, 7));
+    try testing.expectEqual(@as(u32, 0), try render(&out, testing.allocator, &store, 7, ""));
     try testing.expect(std.mem.indexOf(u8, out.items, "No open comments") != null);
 }
 

--- a/src/core/review.zig
+++ b/src/core/review.zig
@@ -42,11 +42,8 @@ pub fn path(buf: []u8, n: u32) []const u8 {
 /// with a warning rather than being dropped on its way to the agent. Hard rule
 /// 7 does not stop at the screen.
 /// `scope` says what the line numbers below belong to, and is empty for the
-/// working tree, where they belong to the files on disk.
-///
-/// A review of a pull request is a review of somebody else's tree. Without
-/// this the agent reads `src/config.zig:8` and looks at line 8 of the checkout
-/// it is standing in, which is different code, and nothing says so.
+/// working tree. A pull request is somebody else's tree: without it the agent
+/// resolves `src/config.zig:8` against the checkout it stands in.
 pub fn render(
     out: *std.ArrayList(u8),
     gpa: Allocator,
@@ -107,7 +104,11 @@ pub fn render(
             first = false;
 
             try out.appendSlice(gpa, "\n- **line ");
-            try out.appendSlice(gpa, std.fmt.bufPrint(&num, "{d}", .{m.line}) catch "");
+            if (m.span > 1) {
+                try out.appendSlice(gpa, std.fmt.bufPrint(&num, "{d}-{d}", .{ m.line, m.end() }) catch "");
+            } else {
+                try out.appendSlice(gpa, std.fmt.bufPrint(&num, "{d}", .{m.line}) catch "");
+            }
             try out.appendSlice(gpa, "**");
             // A stale comment says so in the file as well as on screen. The agent
             // should know the line moved out from under the remark rather than
@@ -133,6 +134,18 @@ fn indent(out: *std.ArrayList(u8), gpa: Allocator, body: []const u8) Allocator.E
         try out.appendSlice(gpa, line);
         try out.appendSlice(gpa, "\n");
     }
+}
+
+test "a remark on several lines says so" {
+    var store: comments.Store = .init(testing.allocator);
+    defer store.deinit();
+    _ = try store.addFull("a.zig", 44, "these three belong together", "", false, 3);
+
+    var out: std.ArrayList(u8) = .empty;
+    defer out.deinit(testing.allocator);
+    _ = try render(&out, testing.allocator, &store, 1, "");
+    // The first line alone is a third of the problem.
+    try testing.expect(std.mem.indexOf(u8, out.items, "**line 44-46**") != null);
 }
 
 test "a review of somebody else's tree says whose" {

--- a/src/main.zig
+++ b/src/main.zig
@@ -201,6 +201,8 @@ pub fn main(init: std.process.Init) !void {
     var pr_arena: std.heap.ArenaAllocator = .init(gpa);
     defer pr_arena.deinit();
     var pr_label: []const u8 = "";
+    var pr_scope: u32 = 0;
+    var pr_repo: []const u8 = "";
     if (want_pr) {
         if (base != null or target != null) {
             // Winning quietly would review something the reader did not ask
@@ -219,6 +221,8 @@ pub fn main(init: std.process.Init) !void {
         base = refs.base;
         target = refs.target;
         pr_label = refs.label;
+        pr_scope = refs.number;
+        pr_repo = refs.repo;
     }
 
     try loop.run(gpa, io, init.environ_map, .{
@@ -229,6 +233,8 @@ pub fn main(init: std.process.Init) !void {
         .base = base,
         .target = target,
         .label = pr_label,
+        .pr = pr_scope,
+        .repo = pr_repo,
     });
 
     if (want_profile) try metrics.report(w);

--- a/src/ui/app.zig
+++ b/src/ui/app.zig
@@ -337,6 +337,14 @@ pub const App = struct {
     pr_base_len: u8 = 0,
     pr_target: [64]u8 = undefined,
     pr_target_len: u8 = 0,
+    /// Which pull request the comment store belongs to, or zero for the
+    /// working tree. Remarks written against somebody else's branch are not
+    /// remarks about the tree on disk, and one file for both re-anchored them
+    /// onto whatever line they landed near.
+    pr_number: u32 = 0,
+    /// `owner/repo`, so posting does not have to ask again.
+    pr_repo: [128]u8 = undefined,
+    pr_repo_len: u8 = 0,
     /// Every path in the project, from `git ls-files`, loaded the first time
     /// `@` asks and kept for the session. Not loaded at startup: most sessions
     /// never mention a file, and cold start has a 50 ms budget.
@@ -1043,6 +1051,7 @@ pub const App = struct {
             },
             .comment_send => try self.commentSend(),
             .comment_send_one => try self.listSendOne(),
+            .comment_post_one => self.postOne(),
             .comment_send_all => {
                 self.closeFiles();
                 try self.submitReview();
@@ -1435,9 +1444,21 @@ pub const App = struct {
     /// which is most of what orients a reader in a hunk they have not scrolled
     /// to yet.
     fn diffHead(arena: Allocator, f: diff.FileDiff) []const u8 {
+        return diffText(arena, f, null);
+    }
+
+    /// As `diffHead`, from the hunk that contains `at` rather than the first.
+    /// What a comment is *about*, which is the one thing its row does not
+    /// already say.
+    pub fn diffText(arena: Allocator, f: diff.FileDiff, at: ?u32) []const u8 {
         var out: std.ArrayList(u8) = .empty;
         var lines: usize = 0;
+        var started = at == null;
         for (f.hunks) |h| {
+            if (!started) {
+                if (h.overlapsNew(at.?, 1) == 0) continue;
+                started = true;
+            }
             if (lines >= preview_lines or out.items.len >= preview_bytes) break;
             out.print(arena, "@@ -{d},{d} +{d},{d} @@{s}{s}\n", .{
                 h.old_start,                        h.old_count,
@@ -1690,9 +1711,12 @@ pub const App = struct {
                     // elided towards a name it does not end with.
                     .icon_path = n.path,
                     .detail = if (self.previews()) std.mem.trimEnd(u8, detail, " ") else "",
-                    // Copied for the reason the label is: the store is edited
-                    // and deleted from while the list is open.
-                    .preview = if (self.previews()) arena.dupe(u8, n.body) catch "" else "",
+                    // The code, not the remark. The row already carries the
+                    // remark, and a panel repeating it beside its own row is a
+                    // panel saying nothing. What is missing is what it is
+                    // about; `<Space>vc` is still how a long one is read whole.
+                    .preview = if (self.previews()) self.commentCode(arena, n.path, n.line) else "",
+                    .preview_kind = .diff,
                 }) catch return;
             }
             return;
@@ -2038,6 +2062,9 @@ pub const App = struct {
         // the table and never will be.
         if (settingOf(typed)) |s| {
             if (std.mem.eql(u8, s.setting.verb, "pr")) return self.openPr(s.arg);
+            if (std.mem.eql(u8, s.setting.verb, "post")) return self.postReview(.comment, s.arg);
+            if (std.mem.eql(u8, s.setting.verb, "approve")) return self.postReview(.approve, s.arg);
+            if (std.mem.eql(u8, s.setting.verb, "request-changes")) return self.postReview(.request_changes, s.arg);
             return self.setTheme(s.arg);
         }
 
@@ -2111,6 +2138,9 @@ pub const App = struct {
         // every `<Tab>` is a network call for a list the reader already has
         // in the branch they are on.
         .{ .verb = "pr", .names = &.{} },
+        .{ .verb = "post", .names = &.{} },
+        .{ .verb = "approve", .names = &.{} },
+        .{ .verb = "request-changes", .names = &.{} },
         // vim's spelling, for the reader who arrives already knowing it.
         .{ .verb = "colorscheme", .names = theme_mod.bundled_names },
         .{ .verb = "colo", .names = theme_mod.bundled_names },
@@ -2156,6 +2186,100 @@ pub const App = struct {
         self.notice.set("theme {s} - to keep it: [theme] name = \"{s}\"", .{ found.name, found.name });
     }
 
+    /// What the line numbers in a review file belong to. Empty for the working
+    /// tree, where they belong to the files on disk.
+    fn reviewScope(self: *const App, buf: []u8) []const u8 {
+        if (self.pr_number == 0) return "";
+        return std.fmt.bufPrint(
+            buf,
+            "Pull request #{d}, {s}. Line numbers are that tree, not the working one: `gh pr checkout {d}`.",
+            .{ self.pr_number, self.postRepo() orelse "", self.pr_number },
+        ) catch "";
+    }
+
+    /// The repository a pull request review is posted to, remembered from the
+    /// resolve so posting costs no second question.
+    fn postRepo(self: *const App) ?[]const u8 {
+        if (self.pr_number == 0 or self.pr_repo_len == 0) return null;
+        return self.pr_repo[0..self.pr_repo_len];
+    }
+
+    /// `:post`, `:approve`, `:request-changes`. One review, one request, so a
+    /// partial failure cannot happen.
+    ///
+    /// The argument, if any, is the covering note the review opens with. An
+    /// approval needs nothing to say; the other two do, or there is no reason
+    /// to have notified anybody.
+    fn postReview(self: *App, want: gh.Event, note: []const u8) void {
+        const repo = self.postRepo() orelse {
+            self.notice.set("not reviewing a pull request", .{});
+            return;
+        };
+
+        var scratch: std.heap.ArenaAllocator = .init(self.gpa);
+        defer scratch.deinit();
+        const arena = scratch.allocator();
+
+        var out: std.ArrayList(u8) = .empty;
+        var ids: std.ArrayList(u32) = .empty;
+        gh.reviewBody(&out, arena, &self.comments, self.review.files(), want, note, &ids) catch {
+            self.notice.set("could not build the review", .{});
+            return;
+        };
+        if (ids.items.len == 0 and want != .approve and note.len == 0) {
+            if (self.comments.len() == 0) {
+                self.notice.set("no comments to post", .{});
+            } else {
+                self.notice.set("everything here is posted already", .{});
+            }
+            return;
+        }
+
+        gh.post(self.gpa, arena, self.io, repo, self.pr_number, out.items) catch {
+            self.notice.set("could not post the review", .{});
+            return;
+        };
+        self.comments.markPosted(ids.items);
+        self.saveComments();
+        self.closeFiles();
+        self.notice.set("posted {d} to #{d} as {s}", .{ ids.items.len, self.pr_number, want.wire() });
+    }
+
+    /// `<C-p>` in the comment list: the one under the cursor, on its own.
+    /// GitHub's "add single comment" beside "submit review", which is the
+    /// split every reader already knows from the web.
+    fn postOne(self: *App) void {
+        const n = self.listSelected() orelse return;
+        if (self.postRepo() == null) {
+            self.notice.set("not reviewing a pull request", .{});
+            return;
+        }
+        if (n.posted) {
+            self.notice.set("already posted", .{});
+            return;
+        }
+        const id = n.id;
+        var one: comments_mod.Store = .init(self.gpa);
+        defer one.deinit();
+        _ = one.addFull(n.path, n.line, n.body, n.anchor, n.about_removed) catch return;
+        one.list.items[0].state = n.state;
+
+        var scratch: std.heap.ArenaAllocator = .init(self.gpa);
+        defer scratch.deinit();
+        const arena = scratch.allocator();
+        var out: std.ArrayList(u8) = .empty;
+        var ids: std.ArrayList(u32) = .empty;
+        gh.reviewBody(&out, arena, &one, self.review.files(), .comment, "", &ids) catch return;
+
+        gh.post(self.gpa, arena, self.io, self.postRepo().?, self.pr_number, out.items) catch {
+            self.notice.set("could not post that comment", .{});
+            return;
+        };
+        self.comments.markPosted(&.{id});
+        self.saveComments();
+        self.notice.set("posted {s}:{d}", .{ n.path, n.line });
+    }
+
     /// `:pr [n]`, or `:pr off` for the working tree. The same resolve `--pr`
     /// runs, so the two spellings cannot disagree about what a request is.
     fn openPr(self: *App, arg: []const u8) void {
@@ -2182,6 +2306,9 @@ pub const App = struct {
         self.review.base = self.keepRef(&self.pr_base, &self.pr_base_len, refs.base);
         self.review.target = self.keepRef(&self.pr_target, &self.pr_target_len, refs.target);
         self.review.setLabel(refs.label);
+        self.pr_repo_len = @intCast(@min(refs.repo.len, self.pr_repo.len));
+        @memcpy(self.pr_repo[0..self.pr_repo_len], refs.repo[0..self.pr_repo_len]);
+        self.swapComments(refs.number);
         self.reopen();
         // Not the label: the badge shows it already. What is new is that the
         // review has stopped following the working tree.
@@ -2208,6 +2335,8 @@ pub const App = struct {
         self.review.setLabel("");
         self.pr_base_len = 0;
         self.pr_target_len = 0;
+        self.pr_repo_len = 0;
+        self.swapComments(0);
         self.reopen();
         self.notice.set("back to the working tree", .{});
     }
@@ -2568,6 +2697,42 @@ pub const App = struct {
         try testing.expectEqualStrings("HEAD", fx.app.review.base);
     }
 
+    test "remarks on a pull request do not follow you to the working tree" {
+        var fx = try Fixture.init(testing.allocator);
+        defer fx.deinit();
+
+        // One file per scope, so nothing has to filter and a working-tree
+        // review never re-anchors somebody else's branch onto the tree here.
+        var buf: [64]u8 = undefined;
+        try testing.expectEqualStrings(".lgtm/comments.jsonl", fx.app.commentsPath(&buf));
+        fx.app.pr_number = 13;
+        try testing.expectEqualStrings(".lgtm/pr-13.jsonl", fx.app.commentsPath(&buf));
+    }
+
+    test "swapping scope empties the store and reloads the new one" {
+        var fx = try Fixture.init(testing.allocator);
+        defer fx.deinit();
+
+        _ = try fx.app.comments.add("a.zig", 1, "about the working tree");
+        try testing.expectEqual(@as(usize, 1), fx.app.comments.len());
+        // Nothing here may write to the repository the tests run in.
+        fx.app.comments.dirty = false;
+
+        // A scope with no file: the store comes back empty rather than
+        // carrying the previous one's remarks across, and rather than picking
+        // up `notes.jsonl`, which belongs to the working tree alone.
+        fx.app.swapComments(999_999);
+        try testing.expectEqual(@as(usize, 0), fx.app.comments.len());
+        try testing.expectEqual(@as(u32, 999_999), fx.app.pr_number);
+
+        // Asking for the scope already open is not a reload: it would drop
+        // unsaved remarks on the way out and back.
+        _ = try fx.app.comments.add("b.zig", 2, "about the request");
+        fx.app.comments.dirty = false;
+        fx.app.swapComments(999_999);
+        try testing.expectEqual(@as(usize, 1), fx.app.comments.len());
+    }
+
     test "a failed pull request leaves the review pointing where it was" {
         var fx = try Fixture.init(testing.allocator);
         defer fx.deinit();
@@ -2877,25 +3042,61 @@ pub const App = struct {
         try testing.expect(std.mem.indexOf(u8, fx.app.pick_list.items[0].path, "a remark") != null);
     }
 
-    test "a comment keeps its whole remark for the panel beside the list" {
+    test "a comment's panel starts at the hunk it sits in" {
+        var fx = try Fixture.init(testing.allocator);
+        defer fx.deinit();
+        const arena = fx.app.pick_arena.allocator();
+
+        var kinds = [_]hunk.LineKind{ .context, .add, .context, .add };
+        var olds = [_]u32{ 1, 0, 90, 0 };
+        var news = [_]u32{ 1, 2, 90, 91 };
+        var texts = [_][]const u8{ "top of file", "first change", "further down", "second change" };
+        var hunks = [_]hunk.Hunk{
+            .{ .old_start = 1, .old_count = 1, .new_start = 1, .new_count = 2, .lo = 0, .hi = 2 },
+            .{ .old_start = 90, .old_count = 1, .new_start = 90, .new_count = 2, .lo = 2, .hi = 4 },
+        };
+        const f: diff.FileDiff = .{
+            .old_path = "a.zig",
+            .new_path = "a.zig",
+            .status = .modified,
+            .hunks = &hunks,
+            .lines = .{ .kind = &kinds, .old_no = &olds, .new_no = &news, .text = &texts },
+        };
+
+        // A remark on line 91 is about the second hunk, and showing the first
+        // would be showing the wrong code with total confidence.
+        const at = App.diffText(arena, f, 91);
+        try testing.expect(std.mem.startsWith(u8, at, "@@ -90,1 +90,2 @@"));
+        try testing.expect(std.mem.indexOf(u8, at, "second change") != null);
+        try testing.expect(std.mem.indexOf(u8, at, "first change") == null);
+
+        // The file list wants the head instead, which is the same walk from
+        // the first hunk.
+        try testing.expect(std.mem.startsWith(u8, App.diffText(arena, f, null), "@@ -1,1 +1,2 @@"));
+
+        // A line in no hunk at all shows nothing rather than the nearest thing.
+        try testing.expectEqualStrings("", App.diffText(arena, f, 5000));
+    }
+
+    test "a comment's panel shows the code, not the comment again" {
         var fx = try Fixture.init(testing.allocator);
         defer fx.deinit();
 
-        const body = "the retry loop here\nnever backs off, so a flapping\nhost gets hammered";
+        const body = "the retry loop here\nnever backs off";
         _ = try fx.app.comments.add("src/net.zig", 47, body);
         fx.app.files_purpose = .comments;
         fx.app.buildPickList();
 
         const row = fx.app.pick_list.items[0];
-        // The row keeps the flattened body, because the filter reaches only
-        // what the label holds.
+        // The row carries the remark, flattened, because that is what the
+        // filter reads.
         try testing.expect(std.mem.indexOf(u8, row.path, "src/net.zig:47") != null);
         try testing.expect(std.mem.indexOfScalar(u8, row.path, '\n') == null);
-        // The panel gets it as it was written. `flatten` and its 256-byte
-        // buffer turned a paragraph into a first sentence with no way to read
-        // the rest.
-        try testing.expectEqualStrings(body, row.preview);
         try testing.expectEqualStrings("src/net.zig:47", row.detail);
+        // And the panel does not repeat it: a panel saying what its own row
+        // says is a panel saying nothing. The fixture has no diff for the
+        // file, so there is nothing to show and nothing is invented.
+        try testing.expect(std.mem.indexOf(u8, row.preview, "retry loop") == null);
     }
 
     test "a backend that reports only ids still gets a list worth reading" {
@@ -3536,7 +3737,13 @@ pub const App = struct {
         var buf: [compose_mod.max_bytes]u8 = undefined;
         var flat: [compose_mod.max_bytes]u8 = undefined;
         const one = compose_mod.flatten(&flat, n.body);
-        const line = std.fmt.bufPrint(&buf, "{s}:{d} - {s}", .{ n.path, n.line, one }) catch one;
+        // The pull request comes first for the same reason the review file
+        // names it: `path:line` on somebody else's tree is a different line
+        // here.
+        const line = if (self.pr_number == 0)
+            std.fmt.bufPrint(&buf, "{s}:{d} - {s}", .{ n.path, n.line, one }) catch one
+        else
+            std.fmt.bufPrint(&buf, "PR #{d} {s}:{d} - {s}", .{ self.pr_number, n.path, n.line, one }) catch one;
         n.state = .sent;
         self.comments.dirty = true;
 
@@ -3763,7 +3970,8 @@ pub const App = struct {
 
         var out: std.ArrayList(u8) = .empty;
         defer out.deinit(self.gpa);
-        const written = try review_file.render(&out, self.gpa, &self.comments, self.review_n);
+        var scope_buf: [256]u8 = undefined;
+        const written = try review_file.render(&out, self.gpa, &self.comments, self.review_n, self.reviewScope(&scope_buf));
 
         var buf: [64]u8 = undefined;
         const rel = review_file.path(&buf, self.review_n);
@@ -3800,24 +4008,61 @@ pub const App = struct {
         self.want_send = .send;
     }
 
+    /// The hunk a comment sits in, as diff text for its panel.
+    fn commentCode(self: *const App, arena: Allocator, path: []const u8, line: u32) []const u8 {
+        for (self.review.files()) |f| {
+            if (!std.mem.eql(u8, f.path(), path)) continue;
+            return diffText(arena, f, line);
+        }
+        return "";
+    }
+
+    /// Where this review's remarks live. One file per scope rather than a
+    /// field on each comment: nothing has to filter, and "my remarks on this
+    /// pull request" is a file read.
+    fn commentsPath(self: *const App, buf: []u8) []const u8 {
+        if (self.pr_number == 0) return ".lgtm/comments.jsonl";
+        return std.fmt.bufPrint(buf, ".lgtm/pr-{d}.jsonl", .{self.pr_number}) catch
+            ".lgtm/comments.jsonl";
+    }
+
     pub fn saveComments(self: *App) void {
         if (!self.comments.dirty) return;
         var out: std.ArrayList(u8) = .empty;
         defer out.deinit(self.gpa);
         comments_mod.write(&out, self.gpa, &self.comments) catch return;
-        fs_mod.writeStateFile(self.io, ".lgtm/comments.jsonl", out.items) catch return;
+        var buf: [64]u8 = undefined;
+        fs_mod.writeStateFile(self.io, self.commentsPath(&buf), out.items) catch return;
         self.comments.dirty = false;
+    }
+
+    /// Puts the current scope's remarks away and brings the new scope's out.
+    fn swapComments(self: *App, number: u32) void {
+        if (self.pr_number == number) return;
+        self.saveComments();
+        self.comments.deinit();
+        self.comments = .init(self.gpa);
+        self.pr_number = number;
+        self.loadComments();
     }
 
     pub fn loadComments(self: *App) void {
         // `.lgtm/notes.jsonl` is the name this file had before the feature was
         // called comments. Read once and it is written back under the new
         // name: renaming a concept should not lose a reader's remarks.
-        const text = fs_mod.readFile(self.io, self.gpa, ".lgtm/comments.jsonl", 1 << 20) catch
-            fs_mod.readFile(self.io, self.gpa, ".lgtm/notes.jsonl", 1 << 20) catch return;
+        var buf: [64]u8 = undefined;
+        const path = self.commentsPath(&buf);
+        // The rename predates the scopes, so only the working tree ever wore
+        // the old name. Offering it to every scope handed one file's remarks
+        // to whichever pull request was opened first.
+        const text = fs_mod.readFile(self.io, self.gpa, path, 1 << 20) catch
+            if (self.pr_number == 0)
+                fs_mod.readFile(self.io, self.gpa, ".lgtm/notes.jsonl", 1 << 20) catch return
+            else
+                return;
         defer self.gpa.free(text);
         comments_mod.read(&self.comments, text) catch {};
-        if (self.comments.len() > 0 and !fs_mod.fileExists(self.io, ".lgtm/comments.jsonl")) {
+        if (self.comments.len() > 0 and !fs_mod.fileExists(self.io, path)) {
             self.comments.dirty = true;
             self.saveComments();
         }
@@ -4647,12 +4892,16 @@ pub const App = struct {
     /// moves the footer with the binding.
     fn commentListKeys(self: *App, arena: Allocator) []const keytext.HelpEntry {
         var out: std.ArrayList(keytext.HelpEntry) = .empty;
-        const want = [_]struct { cmd: keymap.Command, desc: []const u8 }{
+        // A footer naming a key that does nothing is worse than a shorter one,
+        // and posting needs a pull request to post to.
+        const want = [_]struct { cmd: keymap.Command, desc: []const u8, pr_only: bool = false }{
             .{ .cmd = .comment_send_one, .desc = "send" },
             .{ .cmd = .comment_send_all, .desc = "send all" },
+            .{ .cmd = .comment_post_one, .desc = "post", .pr_only = true },
             .{ .cmd = .comment_drop, .desc = "del" },
         };
         for (want) |w| {
+            if (w.pr_only and self.pr_number == 0) continue;
             var buf: [32]u8 = undefined;
             const keys = keytext.firstKeyFor(self.km.bindings, w.cmd, .finder, &buf);
             if (keys.len == 0) continue;

--- a/src/ui/app.zig
+++ b/src/ui/app.zig
@@ -201,6 +201,10 @@ pub const App = struct {
     /// What the compose box will do with what is typed: send it, or attach it
     /// to a line as a note. The box itself does not know or care.
     compose_comment: ?u32 = null,
+    /// Where the comment being written belongs, captured when the box opened.
+    /// Opening it clears the selection, so asking again at save time would
+    /// give a range of one line.
+    compose_spot: ?Spot2 = null,
     compose_is_comment: bool = false,
     /// How many reviews have been submitted this session, for the file name.
     review_n: u32 = 0,
@@ -892,13 +896,15 @@ pub const App = struct {
         // repeats its own line number would say it twice in `review-N.md`.
         var what: []const u8 = "compose";
         if (self.compose_is_comment) {
-            what = if (self.commentLine()) |at|
-                (if (at.deleted)
-                    std.fmt.allocPrint(arena, "comment {s}:{d} - removed code", .{ at.path, at.line })
+            // The spot the box opened on: the selection is gone by this
+            // frame, and the title would say one line for a range of three.
+            what = if (self.compose_spot orelse self.commentLine()) |at| blk: {
+                const tail: []const u8 = if (at.deleted) " - removed code" else "";
+                break :blk (if (at.span > 1)
+                    std.fmt.allocPrint(arena, "comment {s}:{d}-{d}{s}", .{ at.path, at.line, at.line + at.span - 1, tail })
                 else
-                    std.fmt.allocPrint(arena, "comment {s}:{d}", .{ at.path, at.line })) catch "comment"
-            else
-                "comment";
+                    std.fmt.allocPrint(arena, "comment {s}:{d}{s}", .{ at.path, at.line, tail })) catch "comment";
+            } else "comment";
         }
         return .{
             .what = what,
@@ -1039,6 +1045,7 @@ pub const App = struct {
                 if (self.readOnly()) return;
                 try self.commentAdd();
             },
+            .comment_suggest => try self.commentSuggest(),
             .comment_view => try self.commentView(body),
             .comment_list => {
                 if (self.mode == .finder) return self.closeFiles();
@@ -2267,7 +2274,7 @@ pub const App = struct {
         var store = &self.comments;
         if (req.one) |id| {
             const n = self.comments.find(id) orelse return;
-            _ = one.addFull(n.path, n.line, n.body, n.anchor, n.about_removed) catch return;
+            _ = one.addFull(n.path, n.line, n.body, n.anchor, n.about_removed, n.span) catch return;
             one.list.items[0].state = n.state;
             store = &one;
         }
@@ -3158,6 +3165,19 @@ pub const App = struct {
         try testing.expectEqual(@as(u16, 2), App.lineCount("a\nb\n"));
     }
 
+    test "a charwise selection across lines still covers those lines" {
+        // `v` is what a reader reaches for as often as `V`, and a comment
+        // anchors to whole lines either way: there is no half a line to
+        // suggest a replacement for. Refusing charwise here fell back to the
+        // cursor's line, which is the *last* of the selection, so choosing
+        // three lines quietly commented on one.
+        var fx = try Fixture.init(testing.allocator);
+        defer fx.deinit();
+
+        try testing.expect(App.Range.covers(.{ .lo = 5, .hi = 7, .rows = 3, .skipped = 0 }) == 3);
+        try testing.expect(App.Range.covers(.{ .lo = 5, .hi = 5, .rows = 1, .skipped = 0 }) == 1);
+    }
+
     test "a comment row is its address; the remark is in the panel and the filter" {
         var fx = try Fixture.init(testing.allocator);
         defer fx.deinit();
@@ -3672,7 +3692,54 @@ pub const App = struct {
     /// The line the cursor points at, as the note store counts them: the new
     /// file's line, which is what survives a re-diff and what a reference
     /// names. Null on a row that is chrome, or a line that exists only in HEAD.
-    const Spot2 = struct { path: []const u8, line: u32, deleted: bool = false };
+    const Spot2 = struct { path: []const u8, line: u32, deleted: bool = false, span: u32 = 1, rows: u32 = 1, skipped: u32 = 0 };
+
+    /// The new-file lines a selection covers, or null when it touches none.
+    /// A remark cannot span code the new file does not have.
+    const Range = struct {
+        lo: u32,
+        hi: u32,
+        rows: u32,
+        skipped: u32,
+
+        /// Lines the remark covers, which is what the store calls its span.
+        pub fn covers(self: Range) u32 {
+            return self.hi - self.lo + 1;
+        }
+    };
+
+    fn selectedRange(self: *App) ?Range {
+        const sel = self.selection() orelse return null;
+        // Both kinds: a comment anchors to whole lines, so the rows a
+        // selection touches matter and where in them it starts does not.
+        // Refusing charwise fell back to the caret's line, the last of them.
+        const f = self.current() orelse return null;
+
+        var lo: u32 = 0;
+        var hi: u32 = 0;
+        var rows: u32 = 0;
+        var skipped: u32 = 0;
+        var row = sel.lo;
+        while (row <= sel.hi) : (row += 1) {
+            rows += 1;
+            const li = self.lineAt(row) orelse {
+                skipped += 1;
+                continue;
+            };
+            if (li >= f.lines.len()) {
+                skipped += 1;
+                continue;
+            }
+            const no = f.lines.new_no[li];
+            if (no == 0) {
+                skipped += 1;
+                continue;
+            }
+            if (lo == 0 or no < lo) lo = no;
+            if (no > hi) hi = no;
+        }
+        return if (lo == 0) null else .{ .lo = lo, .hi = hi, .rows = rows, .skipped = skipped };
+    }
 
     /// The text of a new-file line, for the anchor a comment carries across a
     /// restart. It has to be the line the comment *attached* to, not the one
@@ -3701,7 +3768,18 @@ pub const App = struct {
         const li = self.lineAt(self.vp.cursor) orelse return null;
         if (li >= f.lines.len()) return null;
         const no = f.lines.new_no[li];
-        if (no != 0) return .{ .path = f.path(), .line = no };
+        if (no != 0) {
+            // Anchored at the selection's *first* new-file line: the caret
+            // is at its bottom, and measuring from there covers one line.
+            if (self.selectedRange()) |r| return .{
+                .path = f.path(),
+                .line = r.lo,
+                .span = r.covers(),
+                .rows = r.rows,
+                .skipped = r.skipped,
+            };
+            return .{ .path = f.path(), .line = no };
+        }
 
         // On a deletion: the first surviving line of the hunk it sits in.
         const hi = self.rows.hunkAt(self.vp.cursor) orelse return null;
@@ -3726,14 +3804,55 @@ pub const App = struct {
             self.notice.set("nothing here to comment on", .{});
             return;
         };
-        _ = at;
         self.compose_is_comment = true;
         self.compose_comment = null;
+        self.compose_spot = at;
         self.compose_to = .copy;
         self.outgoing.clearRetainingCapacity();
         self.compose.start("");
         self.preset_index = null;
         self.mode = .note_input;
+    }
+
+    /// `<Space>gc`: a comment box holding the selected lines in a
+    /// ```suggestion fence, so the remark is the edit rather than a
+    /// description of one. The block replaces the lines it is attached to.
+    fn commentSuggest(self: *App) Allocator.Error!void {
+        if (self.readOnly()) return;
+        const at = self.commentLine() orelse {
+            self.notice.set("nothing here to suggest a change to", .{});
+            return;
+        };
+
+        var seed: std.ArrayList(u8) = .empty;
+        defer seed.deinit(self.gpa);
+        try seed.appendSlice(self.gpa, "```suggestion\n");
+        var no = at.line;
+        while (no < at.line + @max(at.span, 1)) : (no += 1) {
+            try seed.appendSlice(self.gpa, self.textOfNewLine(no));
+            try seed.append(self.gpa, '\n');
+        }
+        try seed.appendSlice(self.gpa, "```");
+
+        self.compose_is_comment = true;
+        self.compose_comment = null;
+        self.compose_spot = at;
+        self.compose_to = .copy;
+        self.outgoing.clearRetainingCapacity();
+        self.compose.start(seed.items);
+        // Inside the fence: the reader came to change that, not to write
+        // around it.
+        self.compose.cursor = "```suggestion\n".len;
+        self.preset_index = null;
+        self.mode = .note_input;
+
+        // A selection can shrink for a good reason - a removed line has
+        // nothing to replace - but shrinking silently looks broken.
+        if (at.skipped > 0) {
+            self.notice.set("suggesting {d} of {d} selected rows: {d} are not lines in the new file", .{
+                at.span, at.rows, at.skipped,
+            });
+        }
     }
 
     /// The same box, seeded with what the comment already says.
@@ -4171,6 +4290,7 @@ pub const App = struct {
     fn closeCompose(self: *App) void {
         self.compose.close();
         self.preset_index = null;
+        self.compose_spot = null;
         self.mode = .normal;
     }
 
@@ -4275,9 +4395,10 @@ pub const App = struct {
             return null;
         }
         const editing = self.compose_comment;
-        const at = self.commentLine();
+        const at = self.compose_spot orelse self.commentLine();
         self.compose_is_comment = false;
         self.compose_comment = null;
+        self.compose_spot = null;
         self.closeCompose();
 
         var id: u32 = 0;
@@ -4285,7 +4406,7 @@ pub const App = struct {
             try self.comments.edit(eid, raw);
             id = eid;
         } else if (at) |spot| {
-            id = try self.comments.addFull(spot.path, spot.line, raw, self.textOfNewLine(spot.line), spot.deleted);
+            id = try self.comments.addFull(spot.path, spot.line, raw, self.textOfNewLine(spot.line), spot.deleted, spot.span);
         }
         self.saveComments();
         self.rebuildRows(.line) catch {};
@@ -4312,10 +4433,15 @@ pub const App = struct {
         var buf: [compose_mod.max_bytes]u8 = undefined;
         var flat: [compose_mod.max_bytes]u8 = undefined;
         const one = compose_mod.flatten(&flat, n.body);
-        const line = if (self.pr_number == 0)
-            std.fmt.bufPrint(&buf, "{s}:{d} - {s}", .{ n.path, n.line, one }) catch one
+        var where: [64]u8 = undefined;
+        const at = if (n.span > 1)
+            std.fmt.bufPrint(&where, "{s}:{d}-{d}", .{ n.path, n.line, n.end() }) catch n.path
         else
-            std.fmt.bufPrint(&buf, "PR #{d} {s}:{d} - {s}", .{ self.pr_number, n.path, n.line, one }) catch one;
+            std.fmt.bufPrint(&where, "{s}:{d}", .{ n.path, n.line }) catch n.path;
+        const line = if (self.pr_number == 0)
+            std.fmt.bufPrint(&buf, "{s} - {s}", .{ at, one }) catch one
+        else
+            std.fmt.bufPrint(&buf, "PR #{d} {s} - {s}", .{ self.pr_number, at, one }) catch one;
         self.outgoing.clearRetainingCapacity();
         try self.outgoing.appendSlice(self.gpa, line);
         self.want_send = .send;
@@ -4355,6 +4481,8 @@ pub const App = struct {
                 @memcpy(raw_buf[0..typed.len], typed);
                 const raw = raw_buf[0..typed.len];
                 const how = self.compose_to;
+                // Before the close, which clears it.
+                const spot = self.compose_spot;
                 self.closeCompose();
                 if (line.len == 0) {
                     self.notice.set("nothing to send", .{});
@@ -4365,10 +4493,10 @@ pub const App = struct {
                     if (self.compose_comment) |id| {
                         try self.comments.edit(id, raw);
                         self.notice.set("comment updated", .{});
-                    } else if (self.commentLine()) |at| {
+                    } else if (spot orelse self.commentLine()) |at| {
                         // The line's text goes with the note, so a restart can
                         // find it again when the file moved underneath.
-                        _ = try self.comments.addFull(at.path, at.line, raw, self.textOfNewLine(at.line), at.deleted);
+                        _ = try self.comments.addFull(at.path, at.line, raw, self.textOfNewLine(at.line), at.deleted, at.span);
                         {
                             var kb: [32]u8 = undefined;
                             self.notice.set("comment added - {s} submits the review", .{

--- a/src/ui/app.zig
+++ b/src/ui/app.zig
@@ -345,6 +345,10 @@ pub const App = struct {
     /// `owner/repo`, so posting does not have to ask again.
     pr_repo: [128]u8 = undefined,
     pr_repo_len: u8 = 0,
+    /// The sentence a posted review opens with, held across the frame between
+    /// arming the post and making it.
+    note_buf: [256]u8 = undefined,
+    note_len: u16 = 0,
     /// Every path in the project, from `git ls-files`, loaded the first time
     /// `@` asks and kept for the session. Not loaded at startup: most sessions
     /// never mention a file, and cold start has a 50 ms budget.
@@ -389,6 +393,11 @@ pub const App = struct {
     /// Set by `e`. The run loop owns the terminal, so it - not `run(cmd)` -
     /// is what can hand it to a child process.
     want_editor: bool = false,
+    /// A review the loop should hand to the forge. Armed rather than done on
+    /// the spot: the call takes a second on the network, and the loop draws at
+    /// the top of its iteration, so going through here is what puts a
+    /// `posting...` frame on screen before the freeze rather than after it.
+    want_post: ?Post = null,
     /// Every outgoing string is a template. Config-owned in
     /// v0.2; the defaults are the internal table until then.
     templates: template.Table = .{},
@@ -902,6 +911,7 @@ pub const App = struct {
             .to_agent = self.compose_to == .send,
             .at = self.compose_at,
             .saves = self.compose_is_comment,
+            .posts = self.pr_number != 0,
             .normal = self.compose.mode == .normal,
         };
     }
@@ -1192,6 +1202,7 @@ pub const App = struct {
             .compose_submit,
             .compose_cancel,
             .compose_send_now,
+            .compose_post_now,
             .compose_presets,
             .compose_mention,
             .compose_newline,
@@ -1386,6 +1397,13 @@ pub const App = struct {
     /// fills these from whatever its bridge knows: `ui/app.zig` never sees a
     /// multiplexer. The fields are the parts, not a finished line - ordering
     /// and column widths are decisions about a list.
+    /// A review the loop is to hand to the forge.
+    pub const Post = struct {
+        event: gh.Event,
+        /// One comment by id, or null for every unposted one.
+        one: ?u32 = null,
+    };
+
     pub const PaneRow = struct {
         id: []const u8,
         /// Where the pane is, in whatever the multiplexer calls places.
@@ -1691,31 +1709,29 @@ pub const App = struct {
                     .sent => "[sent] ",
                     .stale => "[stale] ",
                 };
+                // The row is the remark's address, not the remark. It used to
+                // carry the body too, flattened and cut at whatever the column
+                // left, which is unreadable beside a panel showing the whole
+                // thing. The filter still reaches the text; see `filter`.
                 const label = std.fmt.allocPrint(arena, "{s}:{d}  {s}{s}", .{
-                    n.path, n.line, mark, body,
+                    n.path, n.line, mark, if (n.posted) "[posted] " else "",
                 }) catch continue;
-                // The row keeps the flattened body: the filter reaches only
-                // what the label holds. The panel gets the remark as written -
-                // `flatten` and the buffer above it cut a paragraph to a
-                // first sentence.
-                const detail = std.fmt.allocPrint(arena, "{s}:{d}  {s}", .{
-                    n.path, n.line, mark,
-                }) catch continue;
+                const searchable = std.fmt.allocPrint(arena, "{s}:{d}  {s}", .{
+                    n.path, n.line, body,
+                }) catch label;
                 self.pick_list.append(self.gpa, .{
-                    .path = label,
+                    .path = std.mem.trimEnd(u8, label, " "),
+                    .filter = searchable,
                     .added = 0,
                     .removed = 0,
                     .in_review = false,
-                    // The label is composed: the icon comes from the file
-                    // rather than from it, and the row is clipped rather than
-                    // elided towards a name it does not end with.
                     .icon_path = n.path,
-                    .detail = if (self.previews()) std.mem.trimEnd(u8, detail, " ") else "",
-                    // The code, not the remark. The row already carries the
-                    // remark, and a panel repeating it beside its own row is a
-                    // panel saying nothing. What is missing is what it is
-                    // about; `<Space>vc` is still how a long one is read whole.
-                    .preview = if (self.previews()) self.commentCode(arena, n.path, n.line) else "",
+                    .detail = if (self.previews()) std.mem.trimEnd(u8, label, " ") else "",
+                    // The remark first, then the code it is about. Neither is
+                    // in the row any more, and both are what a reader opened
+                    // the list to see.
+                    .preview = if (self.previews()) self.commentPanel(arena, n) else "",
+                    .preview_lead = lineCount(n.body),
                     .preview_kind = .diff,
                 }) catch return;
             }
@@ -2211,22 +2227,11 @@ pub const App = struct {
     /// approval needs nothing to say; the other two do, or there is no reason
     /// to have notified anybody.
     fn postReview(self: *App, want: gh.Event, note: []const u8) void {
-        const repo = self.postRepo() orelse {
+        if (self.postRepo() == null) {
             self.notice.set("not reviewing a pull request", .{});
             return;
-        };
-
-        var scratch: std.heap.ArenaAllocator = .init(self.gpa);
-        defer scratch.deinit();
-        const arena = scratch.allocator();
-
-        var out: std.ArrayList(u8) = .empty;
-        var ids: std.ArrayList(u32) = .empty;
-        gh.reviewBody(&out, arena, &self.comments, self.review.files(), want, note, &ids) catch {
-            self.notice.set("could not build the review", .{});
-            return;
-        };
-        if (ids.items.len == 0 and want != .approve and note.len == 0) {
+        }
+        if (self.unposted() == 0 and want != .approve and note.len == 0) {
             if (self.comments.len() == 0) {
                 self.notice.set("no comments to post", .{});
             } else {
@@ -2234,19 +2239,65 @@ pub const App = struct {
             }
             return;
         }
+        self.note_len = @intCast(@min(note.len, self.note_buf.len));
+        @memcpy(self.note_buf[0..self.note_len], note[0..self.note_len]);
+        self.want_post = .{ .event = want };
+        self.notice.set("posting to #{d}...", .{self.pr_number});
+    }
 
-        gh.post(self.gpa, arena, self.io, repo, self.pr_number, out.items) catch {
-            self.notice.set("could not post the review", .{});
+    fn unposted(self: *const App) usize {
+        var n: usize = 0;
+        for (self.comments.items()) |c| {
+            if (!c.posted) n += 1;
+        }
+        return n;
+    }
+
+    /// The call itself, from the loop, one frame after the notice that says it
+    /// is happening.
+    pub fn performPost(self: *App, req: Post) void {
+        const repo = self.postRepo() orelse return;
+
+        var scratch: std.heap.ArenaAllocator = .init(self.gpa);
+        defer scratch.deinit();
+        const arena = scratch.allocator();
+
+        var one: comments_mod.Store = .init(self.gpa);
+        defer one.deinit();
+        var store = &self.comments;
+        if (req.one) |id| {
+            const n = self.comments.find(id) orelse return;
+            _ = one.addFull(n.path, n.line, n.body, n.anchor, n.about_removed) catch return;
+            one.list.items[0].state = n.state;
+            store = &one;
+        }
+
+        var out: std.ArrayList(u8) = .empty;
+        var ids: std.ArrayList(u32) = .empty;
+        const note = self.note_buf[0..self.note_len];
+        gh.reviewBody(&out, arena, store, self.review.files(), req.event, note, &ids) catch {
+            self.notice.set("could not build the review", .{});
             return;
         };
-        self.comments.markPosted(ids.items);
+
+        gh.post(self.gpa, arena, self.io, repo, self.pr_number, out.items) catch {
+            self.notice.set("could not post to #{d}", .{self.pr_number});
+            return;
+        };
+
+        if (req.one) |id| {
+            self.comments.markPosted(&.{id});
+            self.notice.set("posted 1 to #{d}", .{self.pr_number});
+        } else {
+            self.comments.markPosted(ids.items);
+            self.closeFiles();
+            self.notice.set("posted {d} to #{d} as {s}", .{ ids.items.len, self.pr_number, req.event.wire() });
+        }
         self.saveComments();
-        self.closeFiles();
-        self.notice.set("posted {d} to #{d} as {s}", .{ ids.items.len, self.pr_number, want.wire() });
     }
 
     /// `<C-p>` in the comment list: the one under the cursor, on its own.
-    /// GitHub's "add single comment" beside "submit review", which is the
+    /// GitHub's "add single comment" beside its "submit review", which is the
     /// split every reader already knows from the web.
     fn postOne(self: *App) void {
         const n = self.listSelected() orelse return;
@@ -2258,26 +2309,9 @@ pub const App = struct {
             self.notice.set("already posted", .{});
             return;
         }
-        const id = n.id;
-        var one: comments_mod.Store = .init(self.gpa);
-        defer one.deinit();
-        _ = one.addFull(n.path, n.line, n.body, n.anchor, n.about_removed) catch return;
-        one.list.items[0].state = n.state;
-
-        var scratch: std.heap.ArenaAllocator = .init(self.gpa);
-        defer scratch.deinit();
-        const arena = scratch.allocator();
-        var out: std.ArrayList(u8) = .empty;
-        var ids: std.ArrayList(u32) = .empty;
-        gh.reviewBody(&out, arena, &one, self.review.files(), .comment, "", &ids) catch return;
-
-        gh.post(self.gpa, arena, self.io, self.postRepo().?, self.pr_number, out.items) catch {
-            self.notice.set("could not post that comment", .{});
-            return;
-        };
-        self.comments.markPosted(&.{id});
-        self.saveComments();
-        self.notice.set("posted {s}:{d}", .{ n.path, n.line });
+        self.note_len = 0;
+        self.want_post = .{ .event = .comment, .one = n.id };
+        self.notice.set("posting {s}:{d}...", .{ n.path, n.line });
     }
 
     /// `:pr [n]`, or `:pr off` for the working tree. The same resolve `--pr`
@@ -3039,7 +3073,37 @@ pub const App = struct {
         try testing.expectEqualStrings("", fx.app.pick_list.items[0].preview);
         try testing.expectEqualStrings("", fx.app.pick_list.items[0].detail);
         // The row itself is untouched: the label is what the filter reads.
-        try testing.expect(std.mem.indexOf(u8, fx.app.pick_list.items[0].path, "a remark") != null);
+        try testing.expect(std.mem.indexOf(u8, fx.app.pick_list.items[0].filter, "a remark") != null);
+    }
+
+    test "posting is armed, not done, so the frame saying so is drawn first" {
+        var fx = try Fixture.init(testing.allocator);
+        defer fx.deinit();
+
+        // Outside a pull request there is nothing to arm and the answer is
+        // immediate: a `posting...` that resolved to an error would flash.
+        fx.app.postReview(.comment, "");
+        try testing.expect(fx.app.want_post == null);
+        try testing.expect(std.mem.indexOf(u8, fx.app.notice.text(), "not reviewing") != null);
+
+        fx.app.pr_number = 16;
+        fx.app.pr_repo_len = @intCast("o/r".len);
+        @memcpy(fx.app.pr_repo[0..3], "o/r");
+
+        // Nothing to say is also answered on the spot.
+        fx.app.postReview(.comment, "");
+        try testing.expect(fx.app.want_post == null);
+
+        // With something to post the call is left for the loop, which draws
+        // before it performs.
+        _ = try fx.app.comments.add("a.zig", 1, "a remark");
+        fx.app.postReview(.request_changes, "have a look");
+        const req = fx.app.want_post.?;
+        try testing.expectEqual(gh.Event.request_changes, req.event);
+        try testing.expect(req.one == null);
+        try testing.expect(std.mem.indexOf(u8, fx.app.notice.text(), "posting") != null);
+        // The note outlives the prompt buffer it was typed into.
+        try testing.expectEqualStrings("have a look", fx.app.note_buf[0..fx.app.note_len]);
     }
 
     test "a comment's panel starts at the hunk it sits in" {
@@ -3078,7 +3142,23 @@ pub const App = struct {
         try testing.expectEqualStrings("", App.diffText(arena, f, 5000));
     }
 
-    test "a comment's panel shows the code, not the comment again" {
+    test "the remark leads its panel and is coloured as one" {
+        var fx = try Fixture.init(testing.allocator);
+        defer fx.deinit();
+
+        _ = try fx.app.comments.add("a.zig", 1, "one line\ntwo lines\nthree");
+        fx.app.files_purpose = .comments;
+        fx.app.buildPickList();
+
+        // The lead is the remark's own lines, so the renderer knows how much
+        // of the panel is the reader's words and how much is the code.
+        try testing.expectEqual(@as(u16, 3), fx.app.pick_list.items[0].preview_lead);
+        try testing.expectEqual(@as(u16, 1), App.lineCount("just one"));
+        // A trailing newline does not invent a line.
+        try testing.expectEqual(@as(u16, 2), App.lineCount("a\nb\n"));
+    }
+
+    test "a comment row is its address; the remark is in the panel and the filter" {
         var fx = try Fixture.init(testing.allocator);
         defer fx.deinit();
 
@@ -3088,15 +3168,13 @@ pub const App = struct {
         fx.app.buildPickList();
 
         const row = fx.app.pick_list.items[0];
-        // The row carries the remark, flattened, because that is what the
-        // filter reads.
-        try testing.expect(std.mem.indexOf(u8, row.path, "src/net.zig:47") != null);
-        try testing.expect(std.mem.indexOfScalar(u8, row.path, '\n') == null);
-        try testing.expectEqualStrings("src/net.zig:47", row.detail);
-        // And the panel does not repeat it: a panel saying what its own row
-        // says is a panel saying nothing. The fixture has no diff for the
-        // file, so there is nothing to show and nothing is invented.
-        try testing.expect(std.mem.indexOf(u8, row.preview, "retry loop") == null);
+        // Drawn: where it is. The remark used to be here too, flattened and
+        // cut at whatever the column left, beside a panel showing it whole.
+        try testing.expectEqualStrings("src/net.zig:47", row.path);
+        // Matched: the remark as well, so typing part of one still finds it.
+        try testing.expect(std.mem.indexOf(u8, row.filter, "retry loop") != null);
+        // Shown: the remark as written, unflattened.
+        try testing.expect(std.mem.indexOf(u8, row.preview, "the retry loop here\nnever backs off") != null);
     }
 
     test "a backend that reports only ids still gets a list worth reading" {
@@ -3435,14 +3513,21 @@ pub const App = struct {
         else
             self.templates.ref_single;
 
-        try template.render(self.gpa, out, tmpl, &.{
+        var pr_buf: [12]u8 = undefined;
+        const pr = std.fmt.bufPrint(&pr_buf, "{d}", .{self.pr_number}) catch "";
+        const vars = [_]template.Var{
+            .{ .name = "pr", .value = pr },
             .{ .name = "change_id", .value = id },
             .{ .name = "path", .value = r.path },
             .{ .name = "line", .value = line },
             .{ .name = "start", .value = line },
             .{ .name = "end", .value = end },
             .{ .name = "span", .value = r.span },
-        });
+        };
+        // Every reference, not just the ones a comment carries: `<CR>` sends
+        // one straight from the diff and it lands in the same agent.
+        if (self.pr_number != 0) try template.render(self.gpa, out, self.templates.ref_prefix, &vars);
+        try template.render(self.gpa, out, tmpl, &vars);
     }
 
     /// The lines themselves, under the reference, markers kept. `Y` exists to
@@ -4008,6 +4093,21 @@ pub const App = struct {
         self.want_send = .send;
     }
 
+    pub fn lineCount(text: []const u8) u16 {
+        var n: u16 = 1;
+        for (std.mem.trimEnd(u8, text, "\n")) |c| {
+            if (c == '\n') n += 1;
+        }
+        return n;
+    }
+
+    /// A comment's panel: the remark as written, then the hunk it sits in.
+    fn commentPanel(self: *const App, arena: Allocator, n: comments_mod.Comment) []const u8 {
+        const code = self.commentCode(arena, n.path, n.line);
+        if (code.len == 0) return arena.dupe(u8, n.body) catch "";
+        return std.fmt.allocPrint(arena, "{s}\n\n{s}", .{ n.body, code }) catch code;
+    }
+
     /// The hunk a comment sits in, as diff text for its panel.
     fn commentCode(self: *const App, arena: Allocator, path: []const u8, line: u32) []const u8 {
         for (self.review.files()) |f| {
@@ -4148,6 +4248,7 @@ pub const App = struct {
                 self.mode = .finder;
             },
             .compose_send_now => try self.composeSendNow(body),
+            .compose_post_now => try self.composePostNow(body),
             .compose_submit => try self.composeSubmit(body),
             else => {},
         }
@@ -4157,51 +4258,83 @@ pub const App = struct {
     /// that cannot wait for the batch does not have to be typed, saved,
     /// found again and sent. It is the same key that submits the whole
     /// review from normal mode, which reads as "hand this over" either way.
-    fn composeSendNow(self: *App, body: u16) !void {
-        if (self.compose_is_comment) {
-            var raw_buf: [compose_mod.max_bytes]u8 = undefined;
-            const typed = self.compose.text();
-            @memcpy(raw_buf[0..typed.len], typed);
-            const raw = raw_buf[0..typed.len];
-            if (raw.len == 0) {
-                self.notice.set("nothing to save", .{});
-                return;
-            }
-            const editing = self.compose_comment;
-            const at = self.commentLine();
-            self.compose_is_comment = false;
-            self.compose_comment = null;
-            self.closeCompose();
+    /// What the box holds, saved as a comment. Null when there was nothing to
+    /// save, or when the box is not holding one.
+    ///
+    /// Shared by the two keys that save and then do something with it, which
+    /// otherwise differ only in where the result goes.
+    fn saveComposedComment(self: *App, body: u16) !?u32 {
+        if (!self.compose_is_comment) return null;
 
-            var id: u32 = 0;
-            if (editing) |eid| {
-                try self.comments.edit(eid, raw);
-                id = eid;
-            } else if (at) |spot| {
-                id = try self.comments.addFull(spot.path, spot.line, raw, self.textOfNewLine(spot.line), spot.deleted);
-            }
-            self.saveComments();
-            self.rebuildRows(.line) catch {};
-            if (self.comments.find(id)) |n| {
-                // Handed over, so it is sent: it drops out of the next
-                // `review-N.md` rather than asking twice, and editing it
-                // reopens it the way editing any sent comment does.
-                n.state = .sent;
-                self.comments.dirty = true;
-                self.saveComments();
-                var buf: [compose_mod.max_bytes]u8 = undefined;
-                var flat: [compose_mod.max_bytes]u8 = undefined;
-                const one = compose_mod.flatten(&flat, n.body);
-                const line = std.fmt.bufPrint(&buf, "{s}:{d} - {s}", .{ n.path, n.line, one }) catch one;
-                self.outgoing.clearRetainingCapacity();
-                try self.outgoing.appendSlice(self.gpa, line);
-                self.want_send = .send;
-            }
-            self.clampScroll(body);
+        var raw_buf: [compose_mod.max_bytes]u8 = undefined;
+        const typed = self.compose.text();
+        @memcpy(raw_buf[0..typed.len], typed);
+        const raw = raw_buf[0..typed.len];
+        if (raw.len == 0) {
+            self.notice.set("nothing to save", .{});
+            return null;
+        }
+        const editing = self.compose_comment;
+        const at = self.commentLine();
+        self.compose_is_comment = false;
+        self.compose_comment = null;
+        self.closeCompose();
+
+        var id: u32 = 0;
+        if (editing) |eid| {
+            try self.comments.edit(eid, raw);
+            id = eid;
+        } else if (at) |spot| {
+            id = try self.comments.addFull(spot.path, spot.line, raw, self.textOfNewLine(spot.line), spot.deleted);
+        }
+        self.saveComments();
+        self.rebuildRows(.line) catch {};
+        self.clampScroll(body);
+        return if (id == 0) null else id;
+    }
+
+    fn composeSendNow(self: *App, body: u16) !void {
+        if (!self.compose_is_comment) {
+            // Not a comment: the key means the same thing the plain send does.
+            try self.composeSubmit(body);
             return;
         }
-        // Not a comment: the key means the same thing the plain send does.
-        try self.composeSubmit(body);
+        const id = try self.saveComposedComment(body) orelse return;
+        const n = self.comments.find(id) orelse return;
+
+        // Handed over, so it is sent: it drops out of the next `review-N.md`
+        // rather than asking twice, and editing it reopens it the way editing
+        // any sent comment does.
+        n.state = .sent;
+        self.comments.dirty = true;
+        self.saveComments();
+
+        var buf: [compose_mod.max_bytes]u8 = undefined;
+        var flat: [compose_mod.max_bytes]u8 = undefined;
+        const one = compose_mod.flatten(&flat, n.body);
+        const line = if (self.pr_number == 0)
+            std.fmt.bufPrint(&buf, "{s}:{d} - {s}", .{ n.path, n.line, one }) catch one
+        else
+            std.fmt.bufPrint(&buf, "PR #{d} {s}:{d} - {s}", .{ self.pr_number, n.path, n.line, one }) catch one;
+        self.outgoing.clearRetainingCapacity();
+        try self.outgoing.appendSlice(self.gpa, line);
+        self.want_send = .send;
+    }
+
+    /// `<C-p>` in the box: save and post, without the detour through the list.
+    /// The same arm-then-perform the list's key uses, so the notice saying it
+    /// is happening reaches the screen before the call blocks.
+    fn composePostNow(self: *App, body: u16) !void {
+        if (!self.compose_is_comment) return;
+        if (self.postRepo() == null) {
+            self.notice.set("not reviewing a pull request", .{});
+            return;
+        }
+        const id = try self.saveComposedComment(body) orelse return;
+        const n = self.comments.find(id) orelse return;
+        self.note_len = 0;
+        self.want_post = .{ .event = .comment, .one = id };
+        self.notice.set("posting {s}:{d}...", .{ n.path, n.line });
     }
 
     fn composeSubmit(self: *App, body: u16) !void {

--- a/src/ui/compose.zig
+++ b/src/ui/compose.zig
@@ -366,8 +366,12 @@ pub const Compose = struct {
             // Entering insert, at the five places vim enters it.
             'i' => self.mode = .insert,
             'a' => {
-                self.cursor = motion.charRight(self.line(), self.col()) orelse self.col();
-                self.cursor += self.lineStart();
+                // The line start is read before the caret moves: adding
+                // `lineStart()` afterwards asked a position no longer on the
+                // line, and answered with the top of the box.
+                const at = self.lineStart();
+                const to = motion.charRight(self.line(), self.col()) orelse self.col();
+                self.cursor = at + to;
                 self.mode = .insert;
             },
             'I' => {
@@ -394,6 +398,9 @@ pub const Compose = struct {
                 self.mode = .insert;
             },
             'x' => {
+                // Never across the line's end: `deleteForward` steps over
+                // the newline, so `x` on an empty line joined two.
+                if (self.cursor >= self.lineEnd()) return .typing;
                 self.mark();
                 self.deleteForward();
             },
@@ -595,6 +602,83 @@ fn tap(cp: u21) event.Key {
 
 fn ctrl(cp: u21) event.Key {
     return .{ .codepoint = cp, .mods = .{ .ctrl = true } };
+}
+
+test "the normal-mode keys all work on the line the caret is on" {
+    // Every one of these reads a position and then writes the caret, which is
+    // where `a` went wrong: the box held one line for long enough that mixing
+    // a column with an offset looked the same as not mixing them.
+    var c: Compose = .{};
+    c.start("alpha\nbeta\ngamma");
+    c.mode = .normal;
+
+    // `I` and `A`: the ends of *this* line.
+    c.cursor = 8; // inside "beta"
+    _ = c.feed(tap('I'));
+    try testing.expectEqual(@as(usize, 6), c.cursor);
+    c.mode = .normal;
+    c.cursor = 8;
+    _ = c.feed(tap('A'));
+    try testing.expectEqual(@as(usize, 10), c.cursor);
+
+    // `o` opens below and `O` above, both staying in the middle of the box.
+    c.mode = .normal;
+    c.cursor = 8;
+    _ = c.feed(tap('o'));
+    try testing.expectEqualStrings("alpha\nbeta\n\ngamma", c.buf[0..c.len]);
+
+    var d: Compose = .{};
+    d.start("alpha\nbeta\ngamma");
+    d.mode = .normal;
+    d.cursor = 8;
+    _ = d.feed(tap('O'));
+    try testing.expectEqualStrings("alpha\n\nbeta\ngamma", d.buf[0..d.len]);
+    try testing.expectEqual(@as(usize, 6), d.cursor);
+
+    // `dd` takes the line and its newline, leaving the caret in the box.
+    var e: Compose = .{};
+    e.start("alpha\nbeta\ngamma");
+    e.mode = .normal;
+    e.cursor = 8;
+    _ = e.feed(tap('d'));
+    _ = e.feed(tap('d'));
+    try testing.expectEqualStrings("alpha\ngamma", e.buf[0..e.len]);
+}
+
+test "x deletes a character and never the line break" {
+    var c: Compose = .{};
+    c.start("ab\n\ncd");
+    c.mode = .normal;
+
+    // On a character: that character goes.
+    c.cursor = 0;
+    _ = c.feed(tap('x'));
+    try testing.expectEqualStrings("b\n\ncd", c.buf[0..c.len]);
+
+    // On an empty line: nothing. Joining it to the next is what `deleteForward`
+    // would do, and what vim does not.
+    c.cursor = 2;
+    _ = c.feed(tap('x'));
+    try testing.expectEqualStrings("b\n\ncd", c.buf[0..c.len]);
+}
+
+test "append lands after the cursor on its own line, not at the top of the box" {
+    var c: Compose = .{};
+    c.start("first line\nsecond line\nthird");
+
+    // In the middle of the last line.
+    c.mode = .normal;
+    c.cursor = c.len - 2;
+    _ = c.feed(tap('a'));
+    try testing.expectEqualStrings("third", c.line());
+    try testing.expect(c.cursor > c.len - 3);
+
+    // At the end of a line, `a` appends there rather than jumping anywhere.
+    c.mode = .normal;
+    c.cursor = c.len;
+    _ = c.feed(tap('a'));
+    try testing.expectEqualStrings("third", c.line());
+    try testing.expectEqual(c.len, c.cursor);
 }
 
 test "the arrows move a line at a time, not to the ends of the box" {

--- a/src/ui/compose.zig
+++ b/src/ui/compose.zig
@@ -232,6 +232,44 @@ pub const Compose = struct {
         self.cursor = nextBoundary(self.buf[0..self.len], self.cursor);
     }
 
+    /// The previous line, at the same column or the end of it if that line is
+    /// shorter. The column is bytes rather than display columns, which is what
+    /// every other motion here counts.
+    pub fn lineUp(self: *Compose) void {
+        const here = self.lineStart();
+        if (here == 0) {
+            self.cursor = 0;
+            return;
+        }
+        const want = self.cursor - here;
+        // The line above runs from its own start to the newline before ours.
+        const prev_end = here - 1;
+        var prev_start = prev_end;
+        while (prev_start > 0 and self.buf[prev_start - 1] != '\n') prev_start -= 1;
+        self.cursor = @min(prev_start + want, prev_end);
+        self.snapBoundary();
+    }
+
+    pub fn lineDown(self: *Compose) void {
+        const end_at = self.lineEnd();
+        if (end_at >= self.len) {
+            self.cursor = self.len;
+            return;
+        }
+        const want = self.cursor - self.lineStart();
+        const next_start = end_at + 1;
+        var next_end = next_start;
+        while (next_end < self.len and self.buf[next_end] != '\n') next_end += 1;
+        self.cursor = @min(next_start + want, next_end);
+        self.snapBoundary();
+    }
+
+    /// A column measured on one line can land mid-codepoint on another.
+    fn snapBoundary(self: *Compose) void {
+        while (self.cursor > 0 and self.cursor < self.len and
+            self.buf[self.cursor] & 0xc0 == 0x80) self.cursor -= 1;
+    }
+
     pub fn home(self: *Compose) void {
         self.cursor = 0;
     }
@@ -468,10 +506,12 @@ pub const Compose = struct {
             event.code.backspace => self.backspace(),
             event.code.left => self.left(),
             event.code.right => self.right(),
-            // Up and down are the ends of the text: the box wraps rather than
-            // holding lines, so there is no row above to go to.
-            event.code.up => self.home(),
-            event.code.down => self.end(),
+            // Line by line. They used to be the ends of the text, which was
+            // true when the box held one wrapped paragraph; it holds real
+            // lines now, and jumping to the top from the middle of one is not
+            // what any text box does.
+            event.code.up => self.lineUp(),
+            event.code.down => self.lineDown(),
             else => {
                 // Control bytes that are not bound are dropped rather than
                 // inserted: a stray 0x07 in a payload is invisible here and
@@ -555,6 +595,44 @@ fn tap(cp: u21) event.Key {
 
 fn ctrl(cp: u21) event.Key {
     return .{ .codepoint = cp, .mods = .{ .ctrl = true } };
+}
+
+test "the arrows move a line at a time, not to the ends of the box" {
+    var c: Compose = .{};
+    c.start("short\na much longer line\nmid");
+
+    // From the end of the last line, up keeps the column where it fits.
+    c.end();
+    try testing.expectEqual(c.len, c.cursor);
+    c.lineUp();
+    try testing.expectEqualStrings("a much longer line", c.line());
+    try testing.expectEqual(@as(u32, 3), c.col());
+
+    // And clamps to the end of a shorter line rather than overshooting it.
+    c.lineDown();
+    c.lineUp();
+    c.cursor = c.lineEnd();
+    c.lineUp();
+    try testing.expectEqualStrings("short", c.line());
+    try testing.expectEqual(@as(u32, 5), c.col());
+
+    // Past the first line, up is the very start; past the last, down is the
+    // very end. That is what the arrows used to do from anywhere.
+    c.lineUp();
+    try testing.expectEqual(@as(usize, 0), c.cursor);
+    c.lineDown();
+    c.lineDown();
+    c.lineDown();
+    try testing.expectEqual(c.len, c.cursor);
+}
+
+test "a column measured on one line does not land mid-codepoint on another" {
+    var c: Compose = .{};
+    // `é` is two bytes, so byte column 3 on the second line is inside it.
+    c.start("abcdef\naéb");
+    c.cursor = 3;
+    c.lineDown();
+    try testing.expect(c.buf[c.cursor] & 0xc0 != 0x80);
 }
 
 test "the box opens on the seed with the caret past it" {

--- a/src/ui/files.zig
+++ b/src/ui/files.zig
@@ -156,11 +156,28 @@ pub const Files = struct {
             .max_share = self.max_share,
             .query = filter,
             .index = self.index,
-            .keys = try keytext.helpEntries(bindings, .finder, null, "", arena),
+            .keys = try navKeys(bindings, arena),
             .layout = &self.layout,
         };
     }
 };
+
+/// The list's own keys for the footer, without the ones that move the cursor.
+///
+/// `J K` and `H L` are the first thing a vim reader tries and the last thing
+/// they need told, and in a list with actions on it they were half the footer:
+/// `J K move  H L page  <C-s> send  <C-x> send all  <C-p> post  <C-d> del`
+/// does not fit a split pane, and the half worth keeping is the half nobody
+/// can guess. `?` still lists all of them.
+fn navKeys(bindings: []const keymap.Binding, arena: Allocator) Allocator.Error![]const keytext.HelpEntry {
+    const all = try keytext.helpEntries(bindings, .finder, null, "", arena);
+    var out: std.ArrayList(keytext.HelpEntry) = .empty;
+    for (all) |e| {
+        if (std.mem.eql(u8, e.desc, "move") or std.mem.eql(u8, e.desc, "page")) continue;
+        try out.append(arena, e);
+    }
+    return out.toOwnedSlice(arena);
+}
 
 /// The rows, in review order, narrowed by `query`. Order is the review's, not
 /// a ranking: a reader who knows the change knows roughly where a file sits in

--- a/src/ui/files.zig
+++ b/src/ui/files.zig
@@ -130,7 +130,7 @@ pub const Files = struct {
     pub fn selected(self: *const Files, files: []const frame.FileEntry) ?u32 {
         var shown: usize = 0;
         for (files, 0..) |f, i| {
-            if (fuzzy.match(f.path, self.filter.text()) == null) continue;
+            if (fuzzy.match(matchText(f), self.filter.text()) == null) continue;
             if (shown == self.index) return @intCast(i);
             shown += 1;
         }
@@ -183,6 +183,11 @@ fn navKeys(bindings: []const keymap.Binding, arena: Allocator) Allocator.Error![
 /// a ranking: a reader who knows the change knows roughly where a file sits in
 /// it, and re-sorting on every keystroke takes that away. The tiers still
 /// matter for *which* rows survive, not for where they land.
+/// What a row is matched against: its own text unless it named something else.
+fn matchText(f: frame.FileEntry) []const u8 {
+    return if (f.filter.len > 0) f.filter else f.path;
+}
+
 /// Whether a query is nothing but digits, and so is asking for a `key`.
 ///
 /// Only when some row has one: in the file list `2` should still fuzzy-match a
@@ -218,7 +223,7 @@ pub fn entries(
     const numeric = byNumber(files, query);
     var out: std.ArrayList(frame.FileEntry) = .empty;
     for (files, 0..) |f, i| {
-        const keep = if (numeric) keyMatches(f, query) else fuzzy.match(f.path, query) != null;
+        const keep = if (numeric) keyMatches(f, query) else fuzzy.match(matchText(f), query) != null;
         if (!keep) continue;
         var e = f;
         e.current = i == current;
@@ -233,7 +238,7 @@ pub fn count(files: []const frame.FileEntry, query: []const u8) usize {
     const numeric = byNumber(files, query);
     var n: usize = 0;
     for (files) |f| {
-        const keep = if (numeric) keyMatches(f, query) else fuzzy.match(f.path, query) != null;
+        const keep = if (numeric) keyMatches(f, query) else fuzzy.match(matchText(f), query) != null;
         if (keep) n += 1;
     }
     return n;

--- a/src/ui/frame.zig
+++ b/src/ui/frame.zig
@@ -390,6 +390,11 @@ pub const FileEntry = struct {
     /// worth having: it is the same argument the file list makes, that shape
     /// and hue together find the one you want without reading a name.
     icon_path: []const u8 = "",
+    /// What the filter matches, when that is not what the row draws. A comment
+    /// row shows `path:line` and matches its text too: the remark is worth
+    /// searching and not worth truncating into a column beside the panel that
+    /// shows it whole.
+    filter: []const u8 = "",
     /// One line of facts, drawn above `preview`. Where the pane picker keeps
     /// the id its rows no longer carry.
     detail: []const u8 = "",
@@ -397,6 +402,11 @@ pub const FileEntry = struct {
     /// a pane's own screen, a comment's text, the head of a file's diff.
     /// Empty draws no panel.
     preview: []const u8 = "",
+    /// Lines at the top of `preview` that are the row's own words rather than
+    /// what it is about. A comment's remark leads its panel, and drawn in the
+    /// same grey as the code it sits above it is the least visible thing in a
+    /// list whose whole subject is remarks.
+    preview_lead: u16 = 0,
     /// What `preview` holds: which end of it is shown, and whether its lines
     /// mean anything worth colouring. An enum rather than two flags, which
     /// would allow a fourth combination that means nothing.
@@ -476,6 +486,9 @@ pub const ComposeView = struct {
     /// delivery, which an edit forgot to set - so the box promised the wrong
     /// destination. This is the fact itself rather than a proxy for it.
     saves: bool = false,
+    /// A pull request is on screen, so a saved comment has somewhere to be
+    /// posted. Decides whether the footer offers the key at all.
+    posts: bool = false,
     /// The keymap, so the footer names the keys the reader actually has. The
     /// box's feature keys are `Modes.compose_only` bindings like everything
     /// else; only its motions are fixed.

--- a/src/ui/keymap.zig
+++ b/src/ui/keymap.zig
@@ -75,6 +75,7 @@ pub const Command = enum {
     comment_send,
     comment_send_one,
     comment_send_all,
+    comment_post_one,
     comment_drop,
     comment_view,
     comment_delete,
@@ -588,6 +589,7 @@ pub const default_bindings: []const Binding = &.{
     // A default nobody can press is not a default.
     .{ .chords = &.{ctrl('s')}, .command = .comment_send_one, .modes = Modes.finder_only },
     .{ .chords = &.{ctrl('x')}, .command = .comment_send_all, .modes = Modes.finder_only },
+    .{ .chords = &.{ctrl('p')}, .command = .comment_post_one, .modes = Modes.finder_only },
     .{ .chords = &.{ctrl('d')}, .command = .comment_drop, .modes = Modes.finder_only },
     // Unadvertised aliases: arrows for hands that reach for them, `<C-n>`/
     // `<C-p>` for hands that learned other finders.

--- a/src/ui/keymap.zig
+++ b/src/ui/keymap.zig
@@ -616,7 +616,19 @@ pub const default_bindings: []const Binding = &.{
     // keystroke arriving under its other name rather than a second binding.
     .{ .chords = &.{c(event.code.tab)}, .command = .compose_presets, .modes = Modes.compose_only },
     .{ .chords = &.{c('@')}, .command = .compose_mention, .modes = Modes.compose_only, .desc = "insert a file path at the caret" },
-    .{ .chords = &.{ctrl('j')}, .command = .compose_newline, .modes = Modes.compose_only, .desc = "a line break (Shift-Enter where the terminal sends it)" },
+    // `o` opens a line in the box's normal mode, so this is the same letter
+    // where the reader already is.
+    //
+    // Not `<C-j>` as the first choice, which is the terminal-native newline
+    // and the obvious pick: a vim-tmux-navigator setup binds `C-h/j/k/l` to
+    // move between panes, and tmux swallows it before lgtm is asked. It stays
+    // bound below for anyone whose tmux leaves it alone.
+    .{ .chords = &.{ctrl('o')}, .command = .compose_newline, .modes = Modes.compose_only, .desc = "a line break" },
+    .{ .chords = &.{ctrl('j')}, .command = .compose_newline, .modes = Modes.compose_only },
+    // What every chat box has taught people to press. Only a terminal
+    // reporting the kitty keyboard protocol tells it apart from `<CR>`; where
+    // one does not, this never fires and the two above are the answer.
+    .{ .chords = &.{shift(event.code.enter)}, .command = .compose_newline, .modes = Modes.compose_only },
 
     .{ .chords = &.{c(event.code.tab)}, .command = .list_down, .modes = Modes.lists },
     .{ .chords = &.{shift(event.code.tab)}, .command = .list_up, .modes = Modes.lists },

--- a/src/ui/keymap.zig
+++ b/src/ui/keymap.zig
@@ -187,6 +187,7 @@ pub const Command = enum {
     compose_submit,
     compose_cancel,
     compose_send_now,
+    compose_post_now,
     compose_presets,
     compose_mention,
     compose_newline,
@@ -609,6 +610,7 @@ pub const default_bindings: []const Binding = &.{
     .{ .chords = &.{c(event.code.enter)}, .command = .compose_submit, .modes = Modes.compose_only, .desc = "send what is in the box" },
     .{ .chords = &.{c(event.code.escape)}, .command = .compose_cancel, .modes = Modes.compose_only, .desc = "leave insert, then leave the box" },
     .{ .chords = &.{ctrl('s')}, .command = .compose_send_now, .modes = Modes.compose_only, .desc = "save a comment and send it now" },
+    .{ .chords = &.{ctrl('p')}, .command = .compose_post_now, .modes = Modes.compose_only, .desc = "save a comment and post it to the pull request" },
     .{ .chords = &.{ctrl('i')}, .command = .compose_presets, .modes = Modes.compose_only, .desc = "insert a [presets] question at the caret" },
     // Terminals send 0x09 for both Tab and Ctrl-i, so this is the same
     // keystroke arriving under its other name rather than a second binding.

--- a/src/ui/keymap.zig
+++ b/src/ui/keymap.zig
@@ -79,6 +79,7 @@ pub const Command = enum {
     comment_drop,
     comment_view,
     comment_delete,
+    comment_suggest,
     next_comment,
     prev_comment,
     submit_review,
@@ -436,12 +437,18 @@ pub const leader: Chord = c(' ');
 pub const default_bindings: []const Binding = &.{
     .{ .chords = &.{c('j')}, .command = .line_down, .desc = "down and up a line", .group = .move },
     .{ .chords = &.{c('k')}, .command = .line_up, .desc = "down and up a line", .group = .move },
+    // The arrows move the cursor in the diff too, not only in a list: bound
+    // there alone, `V` and the down arrow left the selection one row long.
+    .{ .chords = &.{c(event.code.down)}, .command = .line_down, .group = .move },
+    .{ .chords = &.{c(event.code.up)}, .command = .line_up, .group = .move },
     .{ .chords = &.{ctrl('d')}, .command = .page_down, .desc = "half a page, down and up", .group = .move },
     .{ .chords = &.{ctrl('u')}, .command = .page_up, .desc = "half a page, down and up", .group = .move },
     .{ .chords = &.{ c('g'), c('g') }, .command = .top, .desc = "first and last line", .group = .move },
     .{ .chords = &.{c('G')}, .command = .bottom, .desc = "first and last line", .group = .move },
     .{ .chords = &.{c('h')}, .command = .char_left, .desc = "left and right a character", .group = .move },
     .{ .chords = &.{c('l')}, .command = .char_right, .desc = "left and right a character", .group = .move },
+    .{ .chords = &.{c(event.code.left)}, .command = .char_left, .group = .move },
+    .{ .chords = &.{c(event.code.right)}, .command = .char_right, .group = .move },
     .{ .chords = &.{c('w')}, .command = .word_next, .desc = "next, previous, end of word", .group = .move },
     .{ .chords = &.{c('b')}, .command = .word_prev, .desc = "next, previous, end of word", .group = .move },
     .{ .chords = &.{c('e')}, .command = .word_end, .desc = "next, previous, end of word", .group = .move },
@@ -495,6 +502,7 @@ pub const default_bindings: []const Binding = &.{
     .{ .chords = &.{ c('['), c('c') }, .command = .prev_comment, .desc = "previous comment (wraps)", .group = .comment },
     .{ .chords = &.{ leader, c('n'), c('c') }, .command = .next_comment, .group = .comment },
     .{ .chords = &.{ leader, c('p'), c('c') }, .command = .prev_comment, .group = .comment },
+    .{ .chords = &.{ leader, c('g'), c('c') }, .command = .comment_suggest, .desc = "suggest a change to these lines, as a comment holding them", .group = .comment },
     .{ .chords = &.{ leader, c('v'), c('c') }, .command = .comment_view, .desc = "open the nearest comment to read or edit", .group = .comment },
     .{ .chords = &.{ leader, c('l'), c('c') }, .command = .comment_list, .desc = "list every comment in the review", .group = .comment },
     .{ .chords = &.{ leader, c('s'), c('c') }, .command = .comment_send, .desc = "send this comment to the agent on its own", .group = .comment },
@@ -764,6 +772,13 @@ test "a single-key binding resolves immediately" {
     var km: Keymap = .{};
     try testing.expectEqual(Command.line_down, km.feed(tap('j'), .normal).command);
     try testing.expectEqual(@as(usize, 0), km.len);
+    // In the diff, not only in a list.
+    try testing.expectEqual(Command.line_down, km.feed(tap(event.code.down), .normal).command);
+    try testing.expectEqual(Command.line_up, km.feed(tap(event.code.up), .normal).command);
+    try testing.expectEqual(Command.line_down, km.feed(tap(event.code.down), .visual).command);
+    try testing.expectEqual(Command.char_right, km.feed(tap(event.code.right), .visual).command);
+    // And a list still gets its own meaning for them.
+    try testing.expectEqual(Command.list_down, km.feed(tap(event.code.down), .finder).command);
 }
 
 test "a two-key sequence waits for its second key" {

--- a/src/ui/keytext.zig
+++ b/src/ui/keytext.zig
@@ -58,6 +58,7 @@ pub fn bufWriteChords(chords: []const Chord, buf: []u8) []const u8 {
             std.fmt.bufPrint(&tmp, "<C-{u}>", .{ch.cp}) catch "<C-?>"
         else if (ch.shift) switch (ch.cp) {
             event.code.tab => "<S-Tab>",
+            event.code.enter => "<S-CR>",
             else => std.fmt.bufPrint(&tmp, "<S-{u}>", .{ch.cp}) catch "<S-?>",
         } else switch (ch.cp) {
             event.code.escape => "<Esc>",
@@ -128,6 +129,7 @@ fn namedChord(name: []const u8) KeyParseError!Chord {
     // matcher could never see.
     if (name.len > 2 and std.ascii.toLower(name[0]) == 's' and name[1] == '-') {
         if (eq(name[2..], "Tab")) return .{ .cp = event.code.tab, .shift = true };
+        if (eq(name[2..], "CR") or eq(name[2..], "Enter")) return .{ .cp = event.code.enter, .shift = true };
         return error.BadKeyName;
     }
     if (eq(name, "Space")) return c(' ');

--- a/src/ui/loop.zig
+++ b/src/ui/loop.zig
@@ -253,6 +253,19 @@ pub fn run(gpa: Allocator, io: std.Io, environ: *std.process.Environ.Map, opts: 
         try drawFrame(&app, &vx, w, body);
         if (opts.once) break;
 
+        // After the frame, deliberately. The call blocks on the network for
+        // about a second, and a reader who pressed a key and saw nothing
+        // assumes the key missed. Armed by the command, performed here, so the
+        // notice saying it is happening is already on screen.
+        if (app.want_post) |req| {
+            app.want_post = null;
+            app.performPost(req);
+            // Straight back to the top rather than on to the wait: what the
+            // call decided has to reach the screen, and the loop blocks for
+            // input until something else happens.
+            continue;
+        }
+
         // Two ways to wait. Settled, the loop blocks - a review pane is idle
         // almost all of the time and should cost nothing while it is. With the
         // viewport still catching up it paces itself instead, and goes back to

--- a/src/ui/loop.zig
+++ b/src/ui/loop.zig
@@ -60,6 +60,11 @@ pub const Options = struct {
     /// Setting it makes the review static, and the three things that watch the
     /// working tree turn themselves off.
     target: ?[]const u8 = null,
+    /// The pull request being reviewed, or zero for the working tree. Decides
+    /// which comment store the review's remarks belong to.
+    pr: u32 = 0,
+    /// `owner/repo` for the pull request, so posting needs no second lookup.
+    repo: []const u8 = "",
     /// What to call the review in the status row, when two shas would say
     /// nothing. `#13 feat: syntax highlight for json` for a pull request.
     label: []const u8 = "",
@@ -197,6 +202,9 @@ pub fn run(gpa: Allocator, io: std.Io, environ: *std.process.Environ.Map, opts: 
     fs.ensureSelfIgnore(io);
     // Notes outlive the process: the whole point of `.lgtm/` is that killing
     // the pane costs scroll position and nothing else.
+    app.pr_number = opts.pr;
+    app.pr_repo_len = @intCast(@min(opts.repo.len, app.pr_repo.len));
+    @memcpy(app.pr_repo[0..app.pr_repo_len], opts.repo[0..app.pr_repo_len]);
     app.loadComments();
     // The store needs an environment to run git in, which only this layer has.
     // Opened before the first diff so `.lgtm/state.json` is read once, and the

--- a/src/ui/popup.zig
+++ b/src/ui/popup.zig
@@ -404,7 +404,12 @@ pub fn fit(m: Metrics, selected: usize, area: Area) ?Box {
     var list_rows: u16 = @intCast(@max(per + @intFromBool(hidden > 0), 1));
     // A panel beside the list is as tall as the list, so a short list makes a
     // short panel rather than a box with a hole in it.
-    if (beside > 0) list_rows = @max(list_rows, @min(m.preview_lines, room -| 3));
+    // The same floor the stacked panel gets: one row is a sliver that reads as
+    // a rendering fault rather than as a small answer.
+    if (beside > 0) list_rows = @max(list_rows, @min(
+        @max(m.preview_lines, preview_rows_min),
+        room -| 3,
+    ));
     const width = content + 4;
     const height = list_rows + 3 + (if (under > 0) under + 1 else 0);
     const col = (area.width -| width) / 2;
@@ -606,10 +611,18 @@ test "the preview goes beside the list, or under it, or not at all" {
     try testing.expectEqual(@as(usize, 8), grown.shown);
 
     // A ceiling, not a floor: two lines do not open a twenty-row box to draw
-    // two lines in it.
+    // two lines in it. The list still sets the height here, being taller.
     few.preview_lines = 2;
     const snug = fit(few, 0, .{ .width = 120, .top = 0, .height = 30 }).?;
     try testing.expectEqual(@as(u16, 8), snug.preview_rows);
+
+    // But a short list and a short panel still clear the floor, or the panel
+    // is a sliver.
+    var tiny_both = few;
+    tiny_both.entries = 1;
+    tiny_both.preview_lines = 1;
+    const floored = fit(tiny_both, 0, .{ .width = 120, .top = 0, .height = 30 }).?;
+    try testing.expectEqual(preview_rows_min, floored.preview_rows);
 
     // And the pane still wins over the ceiling.
     few.preview_lines = preview_rows_beside;

--- a/src/ui/popup.zig
+++ b/src/ui/popup.zig
@@ -325,6 +325,12 @@ pub const gap: u16 = 2;
 /// a share: a list of short names has no use for a wider one.
 pub const min_list_width: u16 = 48;
 
+/// And the ceiling on the whole box. A list plus a panel grows with both, and
+/// on a wide screen that reached the edges: a modal covering everything is a
+/// mode, not an overlay. Beyond this the extra columns buy a longer path and
+/// nothing else.
+pub const max_box_width: u16 = 120;
+
 /// The whole geometry, as a pure function of the measurements. Null when there
 /// is no honest box to draw - below four rows there is no room for a border, a
 /// filter line, one row and a border.
@@ -337,7 +343,7 @@ pub fn fit(m: Metrics, selected: usize, area: Area) ?Box {
     if (area.height < 4 or area.width < 24) return null;
 
     const one = @max(m.keys + gap + m.desc, 12);
-    const max_content = area.width -| 4;
+    const max_content = @min(area.width -| 4, @max(max_box_width, m.min_content));
 
     var cols: u16 = if (m.max_cols > 1 and one * 2 + gap <= max_content and m.entries > 6) 2 else 1;
     var content = @min(max_content, @max(
@@ -705,6 +711,28 @@ test "a deep path does not take the room the panel draws in" {
     try testing.expectEqual(@as(u16, 62 + gap + 8), alone.list_width);
 }
 
+test "a box does not grow to the edges of a wide screen" {
+    var m: Metrics = .{ .keys = 90, .desc = 8, .entries = 20, .title = 6, .footer = 40, .preview = true };
+    m.preview_lines = preview_rows_max;
+    m.min_content = min_list_width;
+
+    // A list and a panel both grow, and together they reached the edges. A
+    // modal covering everything is a mode, not an overlay.
+    const wide = fit(m, 0, .{ .width = 300, .top = 0, .height = 40 }).?;
+    try testing.expect(wide.width <= max_box_width + 4);
+
+    // The pane still wins when it is the smaller of the two.
+    const narrow = fit(m, 0, .{ .width = 70, .top = 0, .height = 40 }).?;
+    try testing.expect(narrow.width <= 70);
+
+    // And the floor outranks the ceiling, or a list of short names in a wide
+    // pane would be capped below the width a list of paths needs.
+    var floor = m;
+    floor.min_content = 200;
+    const tall_floor = fit(floor, 0, .{ .width = 300, .top = 0, .height = 40 }).?;
+    try testing.expect(tall_floor.content >= max_box_width);
+}
+
 test "a list of short names still gets a box worth opening" {
     // Two short paths: the widest row is a dozen columns, and without a floor
     // the box was that wide and resized on every keystroke of the filter.
@@ -1031,12 +1059,24 @@ fn drawPreview(f: Frame, box: Box, e: frame_mod.FileEntry) Allocator.Error!void 
         }
     }
 
+    var at: u16 = 0;
     var it = std.mem.splitScalar(u8, std.mem.trimEnd(u8, e.preview[start..], "\n"), '\n');
-    while (it.next()) |raw| {
+    while (it.next()) |raw| : (at += 1) {
         if (row >= last) break;
-        const line = try path_mod.clip(f.arena, raw, box.preview_width, f.glyphs.ellipsis, f.method());
-        f.put(row, box.preview_col, line, previewStyle(f, e, raw));
-        row += 1;
+        // Wrapped, not clipped. A panel exists to be read, and a remark cut at
+        // the column is the thing the row was already failing to show. Code
+        // wraps too, the way the diff body does.
+        var rest = raw;
+        const style = if (at < e.preview_lead) f.theme.comment_open else previewStyle(f, e, raw);
+        while (row < last) {
+            const take = wrap_mod.fitFront(rest, box.preview_width, f.method());
+            f.put(row, box.preview_col, rest[0..take], style);
+            row += 1;
+            rest = rest[take..];
+            if (rest.len == 0) break;
+            // A width that fits nothing would spin here.
+            if (take == 0) break;
+        }
     }
 }
 
@@ -1287,6 +1327,7 @@ fn composeKeys(f: Frame, v: ComposeView) Allocator.Error![]const keytext.HelpEnt
     try add(f, v, &out, .compose_submit, commit);
     try add(f, v, &out, .compose_cancel, "cancel");
     if (v.saves) try add(f, v, &out, .compose_send_now, "save + send");
+    if (v.saves and v.posts) try add(f, v, &out, .compose_post_now, "save + post");
     if (!v.normal) {
         try add(f, v, &out, .compose_presets, "preset");
         if (!v.saves) try add(f, v, &out, .compose_mention, "file");

--- a/src/ui/popup.zig
+++ b/src/ui/popup.zig
@@ -1326,6 +1326,9 @@ fn composeKeys(f: Frame, v: ComposeView) Allocator.Error![]const keytext.HelpEnt
     });
     try add(f, v, &out, .compose_submit, commit);
     try add(f, v, &out, .compose_cancel, "cancel");
+    // Before the rest, because the footer sheds groups from the end and this
+    // is the one a reader needs on their second sentence.
+    if (!v.normal) try add(f, v, &out, .compose_newline, "line");
     if (v.saves) try add(f, v, &out, .compose_send_now, "save + send");
     if (v.saves and v.posts) try add(f, v, &out, .compose_post_now, "save + post");
     if (!v.normal) {


### PR DESCRIPTION
- Post a comment to PR why reviewing: 
  - `leader-c` -> write -> `c-p` to post a comment
  - `leader-gc` -> edit -> `c-p` to post a comment with suggestion
- Now user can add new line by `c-o`
- Update documentation
- Fix tiny bug with `a` when editing a line

- Ref in: #4 